### PR TITLE
Default arguments in record() test helper

### DIFF
--- a/Tests/ColdBootVisitSpec.swift
+++ b/Tests/ColdBootVisitSpec.swift
@@ -10,7 +10,7 @@ class ColdBootVisitSpec: QuickSpec {
         var visit: ColdBootVisit!
         var visitDelegate: TestVisitDelegate!
         let url = URL(string: "http://localhost/")!
-        
+
         beforeEach {
             webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
             bridge = WebViewBridge(webView: webView)
@@ -18,34 +18,34 @@ class ColdBootVisitSpec: QuickSpec {
             visit = ColdBootVisit(visitable: TestVisitable(url: url), options: VisitOptions(), bridge: bridge)
             visit.delegate = visitDelegate
         }
-        
+
         describe(".start()") {
             beforeEach {
                 expect(visit.state) == .initialized
                 visit.start()
             }
-            
+
             it("transitions to a started state") {
                 expect(visit.state) == .started
             }
-            
+
             it("notifies the delegate the visit will start") {
                 expect(visitDelegate.didCall("visitWillStart(_:)")).toEventually(beTrue())
             }
-            
+
             it("kicks off the web view load") {
                 expect(visit.navigation).toNot(beNil())
             }
-            
+
             it("becomes the navigation delegate") {
                 expect(webView.navigationDelegate) === visit
             }
-            
+
             it("notifies the delegate the visit did start") {
                 visit.start()
                 expect(visitDelegate.didCall("visitDidStart(_:)")).toEventually(beTrue())
             }
-            
+
             it("ignores the call if already started") {
                 visit.start()
                 expect(visitDelegate.methodsCalled.contains("visitDidStart(_:)")).toEventually(beTrue())
@@ -58,65 +58,64 @@ class ColdBootVisitSpec: QuickSpec {
     }
 }
 
-private class TestVisitDelegate: VisitDelegate {
+private class TestVisitDelegate {
     var methodsCalled: Set<String> = []
-    
-    init() {
-    }
-    
+
     func didCall(_ method: String) -> Bool {
         methodsCalled.contains(method)
     }
-    
-    func visitDidInitializeWebView(_ visit: Visit) {
-        record(#function)
-    }
-    
-    func visitWillStart(_ visit: Visit) {
-        record(#function)
-    }
-    
-    func visitDidStart(_ visit: Visit) {
-        record(#function)
-    }
-    
-    func visitDidComplete(_ visit: Visit) {
-        record(#function)
-    }
-    
-    func visitDidFail(_ visit: Visit) {
-        record(#function)
-    }
-    
-    func visitDidFinish(_ visit: Visit) {
-        record(#function)
-    }
-    
-    func visitWillLoadResponse(_ visit: Visit) {
-        record(#function)
-    }
-    
-    func visitDidRender(_ visit: Visit) {
-        record(#function)
-    }
-    
-    func visitRequestDidStart(_ visit: Visit) {
-        record(#function)
-    }
-    
-    func visit(_ visit: Visit, requestDidFailWithError error: Error) {
-        record(#function)
-    }
-    
-    func visitRequestDidFinish(_ visit: Visit) {
-        record(#function)
-    }
-    
-    func visit(_ visit: Visit, didReceiveAuthenticationChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        record(#function)
-    }
-    
-    private func record(_ string: String) {
+
+    private func record(_ string: String = #function) {
         methodsCalled.insert(string)
+    }
+}
+
+extension TestVisitDelegate: VisitDelegate {
+    func visitDidInitializeWebView(_ visit: Visit) {
+        record()
+    }
+
+    func visitWillStart(_ visit: Visit) {
+        record()
+    }
+
+    func visitDidStart(_ visit: Visit) {
+        record()
+    }
+
+    func visitDidComplete(_ visit: Visit) {
+        record()
+    }
+
+    func visitDidFail(_ visit: Visit) {
+        record()
+    }
+
+    func visitDidFinish(_ visit: Visit) {
+        record()
+    }
+
+    func visitWillLoadResponse(_ visit: Visit) {
+        record()
+    }
+
+    func visitDidRender(_ visit: Visit) {
+        record()
+    }
+
+    func visitRequestDidStart(_ visit: Visit) {
+        record()
+    }
+
+    func visit(_ visit: Visit, requestDidFailWithError error: Error) {
+        record()
+    }
+
+    func visitRequestDidFinish(_ visit: Visit) {
+        record()
+    }
+
+    func visit(_ visit: Visit, didReceiveAuthenticationChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        record()
     }
 }


### PR DESCRIPTION
This PR removes the need to add `#function` to each `record()` call, instead opting to use a default argument. It splits out the protocol implementation to an extension to more clearly show what was added for tests.

Also, it cleans up whitespace-only lines.