### PR TITLE
Option to disable logging

### DIFF
--- a/Demo/Demo.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
+++ b/Demo/Demo.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
@@ -50,6 +50,12 @@
             ReferencedContainer = "container:Demo.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "turbo:log"
+            isEnabled = "NO">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Source/Logging.swift
+++ b/Source/Logging.swift
@@ -1,17 +1,18 @@
 import Foundation
 
-/// Simple function to help in debugging, a noop in Release builds
+/// Simple function to help in debugging.
+/// Add the `turbo:log` argument in Xcode to enable.
 func debugLog(_ text: String, _ arguments: [String: Any] = [:]) {
-    #if DEBUG
     let timestamp = Date()
-    
-    print("\(timestamp) \(text) \(arguments)")
-    
-    #endif
+    log("\(timestamp) \(text) \(arguments)")
 }
 
 func debugPrint(_ message: String) {
-    #if DEBUG
-    print(message)
-    #endif
+    log(message)
+}
+
+private func log(_ message: String) {
+    if ProcessInfo.processInfo.arguments.contains("turbo:log") {
+        print(message)
+    }
 }


### PR DESCRIPTION
I've found Turbo logging to be quite verbose and get in the way of my application logs. This PR lets the developer disable Turbo logging by adding the `disableTurboLog` launch argument to their scheme.

<img width="1138" alt="image" src="https://user-images.githubusercontent.com/2092156/106674711-9d993600-6568-11eb-85b7-4cfb2cde4daf.png">

This could have been an environment variable, but the double negative get's weird, and those are parsed as strings. If we wanted to add logging _levels_ then environment variables are the better choice.