### PR TITLE
Allow VisitProposal construction outside of Turbo

### DIFF
--- a/Source/Visit/VisitProposal.swift
+++ b/Source/Visit/VisitProposal.swift
@@ -5,7 +5,7 @@ public struct VisitProposal {
     public let options: VisitOptions
     public let properties: PathProperties
     
-    init(url: URL, options: VisitOptions, properties: PathProperties = [:]) {
+    public init(url: URL, options: VisitOptions, properties: PathProperties = [:]) {
         self.url = url
         self.options = options
         self.properties = properties


### PR DESCRIPTION
I've found myself wanting to use the encapsulated "proposal" concept throughout my codebase.

For example, I have a `VisitCoordinator` that handles visiting the page and presenting the controller. Instead of injecting this with the `URL`, `VisitOptions`, _and_ `PathProperties`, it would be much nicer to keep the concept of `VisitProposal`.

Some simplified example code of what this would look like before/after:

```swift
class VisitCoordinator: Coordinator {
    init(url: URL, options: VisitOptions, properties: PathProperties, session: Session, navigationController: UINavigationController)
    
    func start() {
        let controller = VisitableController(url: url)
        if properties.isModalPresentation {
            navigationController.present(visitable, animated: true)
        } else {
            navigationController.push(visitable, animated: true)
        }
        session.visit(visitable)
    }
}
```

```swift
class VisitCoordinator: Coordinator {
    init(proposal: VisitProposal, session: Session, navigationController: UINavigationController)
    
    func start() {
        let controller = VisitableController(url: proposal.url)
        if proposal.properties.isModalPresentation {
            navigationController.present(visitable, animated: true)
        } else {
            navigationController.push(visitable, animated: true)
        }
        session.visit(visitable)
    }
}
```