### PR TITLE
Initialize path configurations from file synchronously

### DIFF
--- a/Source/Path Configuration/PathConfigurationLoader.swift
+++ b/Source/Path Configuration/PathConfigurationLoader.swift
@@ -131,8 +131,12 @@ final class PathConfigurationLoader {
     // MARK: - Delegate
     
     private func updateHandler(with config: PathConfigurationDecoder) {
-        DispatchQueue.main.async {
+        if Thread.isMainThread {
             self.completionHandler?(config)
+        } else {
+            DispatchQueue.main.async {
+                self.completionHandler?(config)
+            }
         }
     }
 }


### PR DESCRIPTION
Hello,

This adds a condition to load the path configuration synchronously if the loader is already on the main thread (fixes https://github.com/hotwired/turbo-ios/issues/17). :)

Nick