### PR TITLE
Better error message for window.Turbo missing

### DIFF
--- a/Docs/QuickStartGuide.md
+++ b/Docs/QuickStartGuide.md
@@ -40,7 +40,8 @@ extension SceneDelegate: SessionDelegate {
     }
     
     func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error) {
-        print("didFailRequestForVisitable: \(error)")
+        let turboError = error as? TurboError
+        print("didFailRequestForVisitable: \(turboError?.errorDescription ?? error.localizedDescription)")
     }
 }
 ```

--- a/Source/TurboError.swift
+++ b/Source/TurboError.swift
@@ -30,7 +30,7 @@ public enum TurboError: LocalizedError, Equatable {
         case .contentTypeMismatch:
             return "The server returned an invalid content type."
         case .pageLoadFailure:
-            return "The page could not be loaded due to a configuration error."
+            return "The page could not be loaded due to a configuration error, have you added window.Turbo or window.Turbolinks to the page?"
         case .http(let statusCode):
             return "There was an HTTP error (\(statusCode))."
         }

--- a/Source/TurboError.swift
+++ b/Source/TurboError.swift
@@ -30,7 +30,7 @@ public enum TurboError: LocalizedError, Equatable {
         case .contentTypeMismatch:
             return "The server returned an invalid content type."
         case .pageLoadFailure:
-            return "The page could not be loaded due to a configuration error, have you added window.Turbo or window.Turbolinks to the page?"
+            return "The page could not be loaded due to a configuration error, have you added window.Turbo to the page?"
         case .http(let statusCode):
             return "There was an HTTP error (\(statusCode))."
         }


### PR DESCRIPTION
Yep, https://github.com/hotwired/turbo-ios/issues/16 just got me again.