### PR TITLE
Fixes a race condition

### DIFF
--- a/Source/Session/Session.swift
+++ b/Source/Session/Session.swift
@@ -63,10 +63,12 @@ public class Session: NSObject {
         
         let visit = makeVisit(for: visitable, options: options ?? VisitOptions())
         currentVisit?.cancel()
-        currentVisit = visit
-
         visit.delegate = self
         visit.start()
+        
+        currentVisit = visit
+
+
     }
     
     private func makeVisit(for visitable: Visitable, options: VisitOptions) -> Visit {


### PR DESCRIPTION
I ran into a race condition with this. When `currentVisit` gets
re-assigned there are no more references to the JavascriptVisit
it used to hold on to. This will cause it to be deallocated
and the weak ref on the `WebViewBridge` will become null.

The request can finish before the next visit is started and
the new JavascriptVisit is assigned as the delegate.