### PR TITLE
Update the Hotwire subdomains

### DIFF
--- a/Tests/Server/turbo-7.0.0-beta.1.js
+++ b/Tests/Server/turbo-7.0.0-beta.1.js
@@ -827,7 +827,7 @@ Copyright © 2020 Basecamp, LLC
 
         Load your application’s JavaScript bundle inside the <head> element instead. <script> elements in <body> are evaluated with each page change.
 
-        For more information, see: https://turbo.hotwire.dev/handbook/building#working-with-script-elements
+        For more information, see: https://turbo.hotwired.dev/handbook/building#working-with-script-elements
 
         ——
         Suppress this warning by adding a "data-turbo-suppress-warning" attribute to: %s

--- a/Turbo.podspec
+++ b/Turbo.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |spec|
   spec.version        = "7.0.0-beta.1"
   spec.swift_version  = "5.3"
   spec.summary        = "Native iOS Framework for Turbo apps"
-  spec.homepage       = "https://turbo.hotwire.dev/"
+  spec.homepage       = "https://turbo.hotwired.dev/"
   spec.license        = { :type => "MIT", :file => "LICENSE" }
   spec.author         = { "Zach Waugh" => "zwaugh@gmail.com" }
   spec.platform       = :ios, "12.0"


### PR DESCRIPTION
`https://stimulus.hotwire.dev` → `https://stimulus.hotwired.dev`

As per: hotwired/hotwire-site@22a11ac