### PR TITLE
Fixing Xcode warning: class

### DIFF
--- a/Source/Path Configuration/PathConfiguration.swift
+++ b/Source/Path Configuration/PathConfiguration.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public typealias PathProperties = [String: AnyHashable]
 
-public protocol PathConfigurationDelegate: class {
+public protocol PathConfigurationDelegate: AnyObject {
     /// Notifies delegate when a path configuration has been updated with new data
     func pathConfigurationDidUpdate()
 }


### PR DESCRIPTION
Fixing warning: Using 'class' keyword to define a class-constrained protocol is deprecated; use 'AnyObject' instead

Note that this was changed in Swift 4 and is only now (Xcode 13?) issuing a warning.
