### PR TITLE
Register the adapter only after turbo is loaded

### DIFF
--- a/Source/WebView/turbo.js
+++ b/Source/WebView/turbo.js
@@ -13,6 +13,8 @@
         Turbo.registerAdapter(this)
       } else if (window.Turbolinks) {
         Turbolinks.controller.adapter = this
+      } else {
+        throw new Error("Failed to register the TurboNative adapter")
       }
     }
 

--- a/Source/WebView/turbo.js
+++ b/Source/WebView/turbo.js
@@ -167,6 +167,11 @@
     window.turboNative.errorRaised(error)
   }, false)
 
-  window.turboNative = new TurboNative()
-  window.turboNative.pageLoaded()
+  var setup = () => {
+    window.turboNative = new TurboNative()
+    window.turboNative.pageLoaded()
+  }
+
+  window.addEventListener("turbo:load", setup)
+  window.addEventListener("turbolinks:load", setup)
 })()

--- a/Source/WebView/turbo.js
+++ b/Source/WebView/turbo.js
@@ -172,8 +172,8 @@
     window.turboNative.registerAdapter()
     window.turboNative.pageLoaded()
 
-    document.removeEventListener("turbo:load")
-    document.removeEventListener("turbolinks:load")
+    document.removeEventListener("turbo:load", setup)
+    document.removeEventListener("turbolinks:load", setup)
   }
 
   const setupOnLoad = () => {


### PR DESCRIPTION
This PR fixes an issue where the loading of the Turbo JavaScript library is deferred or delayed, which is the case when it's loaded with https://github.com/guybedford/es-module-shims.

We inject `turbo.js` [`atDocumentEnd`](https://github.com/hotwired/turbo-ios/blob/cb6c33b260ee322a2eb32619363ae610777856f1/Source/WebView/WebViewBridge.swift#L52), which executes immediately after the DOM finishes loading but before the page loads its sub-resources. When the script is evaluated, `window.Turbo` isn't yet defined, and the adapter fails the page load immediately.

Fix by using using the `turbo:load` event as the signal that Turbo is loaded and the adapter is ready to be initialized.

If the response to the initial load *isn't* a turbo-enabled page, the `turbo:load` event will never arrive. In that case, we want to display an error. Lacking any way to detect this, we use a timeout. This feels slightly 😬 but is deemed acceptable because this is error case. Better suggestions welcome!

Fixes https://github.com/hotwired/turbo-ios/issues/31