### PR TITLE
Delegate callback when web view process terminates

### DIFF
--- a/Source/Session/Session.swift
+++ b/Source/Session/Session.swift
@@ -297,6 +297,7 @@ extension Session: WKNavigationDelegate {
     
     public func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
         debugLog("[Session] webViewWebContentProcessDidTerminate")
+        delegate?.sessionWebViewProcessDidTerminate(self)
     }
     
     private func openExternalURL(_ url: URL) {

--- a/Source/Session/SessionDelegate.swift
+++ b/Source/Session/SessionDelegate.swift
@@ -10,6 +10,8 @@ public protocol SessionDelegate: AnyObject {
     func sessionDidLoadWebView(_ session: Session)
     func sessionDidStartRequest(_ session: Session)
     func sessionDidFinishRequest(_ session: Session)
+
+    func sessionWebViewProcessDidTerminate(_ session: Session)
 }
 
 public extension SessionDelegate {


### PR DESCRIPTION
This is an intermediary solution for #50.

In summary, `WKWebView` can terminate under certain circumstances when in the background. When a Turbo-powered app is re-opened after this occurs the app can be left in a weird state.

This PR adds a new delegate callback, `sessionWebViewProcessDidTerminate(_:)`, that developers can hook into to do what they see fit. @tony42, for example, is resetting the state of their app. I'm following that same approach.

---

I'm not sure if/how this can be handled better inside of this library short of iOS 16 fixing the issue entirely. So this feels like the next best approach as it puts the power back in the developer's hands.