### PR TITLE
Add missing `sessionWebViewProcessDidTerminate` to Demo

### DIFF
--- a/Demo/SceneController.swift
+++ b/Demo/SceneController.swift
@@ -94,6 +94,9 @@ extension SceneController: SessionDelegate {
     func sessionDidLoadWebView(_ session: Session) {
         session.webView.navigationDelegate = self
     }
+    
+    func sessionWebViewProcessDidTerminate(_ session: Session) {
+    }
 }
 
 extension SceneController: WKNavigationDelegate {


### PR DESCRIPTION
The demo wasn't compiling after https://github.com/hotwired/turbo-ios/pull/56, this fixes it.

@joemasilotti if you have any tips for what to put in this function, it'd make for a better demo 👍