### PR TITLE
Add `sessionWebViewProcessDidTerminate` to quick start

### DIFF
--- a/Docs/QuickStartGuide.md
+++ b/Docs/QuickStartGuide.md
@@ -42,6 +42,10 @@ extension SceneDelegate: SessionDelegate {
     func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error) {
         print("didFailRequestForVisitable: \(error)")
     }
+    
+    func sessionWebViewProcessDidTerminate(_ session: Session) {
+        session.reload()
+    }
 }
 ```
 


### PR DESCRIPTION
https://github.com/hotwired/turbo-ios/issues/50 is a common issue on iOS 15. It looks like every app should implement https://github.com/hotwired/turbo-ios/pull/56

To encourage that, this adds a simple implementation of the function to the quick start.

See also https://github.com/hotwired/turbo-ios/pull/69