### PR TITLE
Improve logging by displaying more relevant details and additional arguments

### DIFF
--- a/Source/Logging.swift
+++ b/Source/Logging.swift
@@ -1,17 +1,12 @@
 import Foundation
 
 /// Simple function to help in debugging, a noop in Release builds
-func debugLog(_ item: Any, _ method: String = #function) {
+func debugLog(_ text: String, _ arguments: [String: Any] = [:]) {
     #if DEBUG
     let timestamp = Date()
     
-    if let message = item as? String {
-        print("\(timestamp) - \(message)")
-    } else {
-        // Support passing object directly instead of string to print class and function
-        let component = String(describing: type(of: item))
-        print("\(timestamp) - [\(component)] \(method)")
-    }
+    print("\(timestamp) \(text) \(arguments)")
+    
     #endif
 }
 

--- a/Source/Session/Session.swift
+++ b/Source/Session/Session.swift
@@ -64,6 +64,8 @@ public class Session: NSObject {
         let visit = makeVisit(for: visitable, options: options ?? VisitOptions())
         currentVisit?.cancel()
         currentVisit = visit
+        
+        log("visit", ["location": visit.location, "options": visit.options, "reload": reload])
 
         visit.delegate = self
         visit.start()
@@ -296,11 +298,12 @@ extension Session: WKNavigationDelegate {
     }
     
     public func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
-        debugLog("[Session] webViewWebContentProcessDidTerminate")
+        log("webViewWebContentProcessDidTerminate")
         delegate?.sessionWebViewProcessDidTerminate(self)
     }
     
     private func openExternalURL(_ url: URL) {
+        log("openExternalURL", ["url": url])
         delegate?.session(self, openExternalURL: url)
     }
 
@@ -333,4 +336,8 @@ extension Session: WKNavigationDelegate {
             navigationAction.targetFrame?.isMainFrame ?? false
         }
     }
+}
+
+private func log(_ name: String, _ arguments: [String: Any] = [:]) {
+    debugLog("[Session] \(name)", arguments)
 }

--- a/Source/Visit/ColdBootVisit.swift
+++ b/Source/Visit/ColdBootVisit.swift
@@ -7,7 +7,7 @@ final class ColdBootVisit: Visit {
     private(set) var navigation: WKNavigation?
 
     override func startVisit() {
-        debugLog(self)
+        log("startVisit")
 
         webView.navigationDelegate = self
         bridge.pageLoadDelegate = self
@@ -23,17 +23,23 @@ final class ColdBootVisit: Visit {
     }
 
     override func cancelVisit() {
+        log("cancelVisit")
+        
         removeNavigationDelegate()
         webView.stopLoading()
         finishRequest()
     }
 
     override func completeVisit() {
+        log("completeVisit")
+        
         removeNavigationDelegate()
         delegate?.visitDidInitializeWebView(self)
     }
 
     override func failVisit() {
+        log("failVisit")
+        
         removeNavigationDelegate()
         finishRequest()
     }
@@ -41,6 +47,10 @@ final class ColdBootVisit: Visit {
     private func removeNavigationDelegate() {
         guard webView.navigationDelegate === self else { return }
         webView.navigationDelegate = nil
+    }
+    
+    private func log(_ name: String) {
+        debugLog("[ColdBootVisit] \(name) \(location.absoluteString)")
     }
 }
 

--- a/Source/Visit/JavaScriptVisit.swift
+++ b/Source/Visit/JavaScriptVisit.swift
@@ -16,26 +16,26 @@ final class JavaScriptVisit: Visit {
     }
 
     override func startVisit() {
-        debugLog(self)
+        log("startVisit")
         bridge.visitDelegate = self
         bridge.visitLocation(location, options: options, restorationIdentifier: restorationIdentifier)
     }
 
     override func cancelVisit() {
-        debugLog(self)
+        log("cancelVisit")
         bridge.cancelVisit(withIdentifier: identifier)
         finishRequest()
     }
 
     override func failVisit() {
-        debugLog(self)
+        log("failVisit")
         finishRequest()
     }
 }
 
 extension JavaScriptVisit: WebViewVisitDelegate {
     func webView(_ webView: WebViewBridge, didStartVisitWithIdentifier identifier: String, hasCachedSnapshot: Bool) {
-        debugLog(self)
+        log("didStartVisitWithIdentifier", ["identifier": identifier, "hasCachedSnapshot": hasCachedSnapshot])
         self.identifier = identifier
         self.hasCachedSnapshot = hasCachedSnapshot
         
@@ -44,13 +44,13 @@ extension JavaScriptVisit: WebViewVisitDelegate {
     
     func webView(_ webView: WebViewBridge, didStartRequestForVisitWithIdentifier identifier: String, date: Date) {
         guard identifier == self.identifier else { return }
-        debugLog(self)
+        log("didFinishRequestForVisitWithIdentifier", ["identifier": identifier, "date": date])
         startRequest()
     }
     
     func webView(_ webView: WebViewBridge, didCompleteRequestForVisitWithIdentifier identifier: String) {
         guard identifier == self.identifier else { return }
-        debugLog(self)
+        log("didCompleteRequestForVisitWithIdentifier", ["identifier": identifier])
         
         if hasCachedSnapshot {
             delegate?.visitWillLoadResponse(self)
@@ -60,28 +60,33 @@ extension JavaScriptVisit: WebViewVisitDelegate {
     func webView(_ webView: WebViewBridge, didFailRequestForVisitWithIdentifier identifier: String, statusCode: Int) {
         guard identifier == self.identifier else { return }
         
+        log("didFailRequestForVisitWithIdentifier", ["identifier": identifier, "statusCode": statusCode])
         fail(with: TurboError(statusCode: statusCode))
     }
     
     func webView(_ webView: WebViewBridge, didFinishRequestForVisitWithIdentifier identifier: String, date: Date) {
         guard identifier == self.identifier else { return }
         
-        debugLog(self)
+        log("didFinishRequestForVisitWithIdentifier", ["identifier": identifier, "date": date])
         finishRequest()
     }
     
     func webView(_ webView: WebViewBridge, didRenderForVisitWithIdentifier identifier: String) {
         guard identifier == self.identifier else { return }
         
-        debugLog(self)
+        log("didRenderForVisitWithIdentifier", ["identifier": identifier])
         delegate?.visitDidRender(self)
     }
     
     func webView(_ webView: WebViewBridge, didCompleteVisitWithIdentifier identifier: String, restorationIdentifier: String) {
         guard identifier == self.identifier else { return }
         
-        debugLog(self)
+        log("didCompleteVisitWithIdentifier", ["identifier": identifier, "restorationIdentifier": restorationIdentifier])
         self.restorationIdentifier = restorationIdentifier
         complete()
+    }
+    
+    private func log(_ name: String, _ arguments: [String: Any] = [:]) {
+        debugLog("[JavascriptVisit] \(name) \(location.absoluteString)", arguments)
     }
 }

--- a/Source/WebView/WebViewBridge.swift
+++ b/Source/WebView/WebViewBridge.swift
@@ -84,7 +84,7 @@ final class WebViewBridge {
             return
         }
         
-        debugLog("[Bridge] → \(function)")
+        debugLog("[Bridge] → \(function) \(arguments)")
 
         webView.evaluateJavaScript(script) { result, error in
             debugLog("[Bridge] = \(function) evaluation complete")
@@ -103,7 +103,7 @@ extension WebViewBridge: ScriptMessageHandlerDelegate {
         guard let message = ScriptMessage(message: scriptMessage) else { return }
         
         if message.name != .log {
-            debugLog("[Bridge] ← \(message.name)")
+            debugLog("[Bridge] ← \(message.name) \(message.data)")
         }
         
         switch message.name {


### PR DESCRIPTION
The current debug logging is insufficient to understand what's going on behind the scenes and investigate issues. This is a step in the right direction. 

Previous log output:
```
2022-06-30 03:29:06 +0000 - [ColdBootVisit] startVisit()
2022-06-30 03:29:07 +0000 - [Bridge] ← pageLoaded
2022-06-30 03:29:09 +0000 - [Bridge] ← visitProposed
2022-06-30 03:29:09 +0000 - [JavaScriptVisit] startVisit()
2022-06-30 03:29:09 +0000 - [Bridge] → window.turboNative.visitLocationWithOptionsAndRestorationIdentifier
2022-06-30 03:29:09 +0000 - [Bridge] ← visitStarted
2022-06-30 03:29:09 +0000 - [JavaScriptVisit] webView(_:didStartVisitWithIdentifier:hasCachedSnapshot:)
2022-06-30 03:29:09 +0000 - [Bridge] ← visitRequestStarted
2022-06-30 03:29:09 +0000 - [JavaScriptVisit] webView(_:didStartRequestForVisitWithIdentifier:date:)
2022-06-30 03:29:09 +0000 - [Bridge] = window.turboNative.visitLocationWithOptionsAndRestorationIdentifier evaluation complete
2022-06-30 03:29:09 +0000 - [Bridge] ← visitRequestFinished
2022-06-30 03:29:09 +0000 - [JavaScriptVisit] webView(_:didFinishRequestForVisitWithIdentifier:date:)
2022-06-30 03:29:09 +0000 - [Bridge] ← visitRequestCompleted
2022-06-30 03:29:09 +0000 - [JavaScriptVisit] webView(_:didCompleteRequestForVisitWithIdentifier:)
2022-06-30 03:29:09 +0000 - [Bridge] ← visitCompleted
2022-06-30 03:29:09 +0000 - [JavaScriptVisit] webView(_:didCompleteVisitWithIdentifier:restorationIdentifier:)
2022-06-30 03:29:09 +0000 - [Bridge] ← visitRendered
2022-06-30 03:29:09 +0000 - [JavaScriptVisit] webView(_:didRenderForVisitWithIdentifier:)
2022-06-30 03:29:11 +0000 - [JavaScriptVisit] startVisit()
2022-06-30 03:29:11 +0000 - [Bridge] → window.turboNative.visitLocationWithOptionsAndRestorationIdentifier
2022-06-30 03:29:11 +0000 - [Bridge] ← visitStarted
2022-06-30 03:29:11 +0000 - [JavaScriptVisit] webView(_:didStartVisitWithIdentifier:hasCachedSnapshot:)
2022-06-30 03:29:11 +0000 - [Bridge] = window.turboNative.visitLocationWithOptionsAndRestorationIdentifier evaluation complete
2022-06-30 03:29:11 +0000 - [Bridge] ← visitCompleted
2022-06-30 03:29:11 +0000 - [JavaScriptVisit] webView(_:didCompleteVisitWithIdentifier:restorationIdentifier:)
2022-06-30 03:29:11 +0000 - [Bridge] ← visitRendered
2022-06-30 03:29:11 +0000 - [JavaScriptVisit] webView(_:didRenderForVisitWithIdentifier:)
```

New log output:
```
2022-06-30 03:30:11 +0000 [Session] visit ["reload": false, "location": https://turbo-native-demo.glitch.me, "options": Turbo.VisitOptions(action: Turbo.VisitAction.replace, response: nil)]
2022-06-30 03:30:11 +0000 [ColdBootVisit] startVisit https://turbo-native-demo.glitch.me [:]
2022-06-30 03:30:12 +0000 [Bridge] ← pageLoaded ["timestamp": 1656559812055, "restorationIdentifier": 42918dac-ca08-4d87-ae88-d866b21e9e14] [:]
2022-06-30 03:30:12 +0000 [ColdBootVisit] completeVisit https://turbo-native-demo.glitch.me [:]
2022-06-30 03:30:18 +0000 [Bridge] ← visitProposed ["location": https://turbo-native-demo.glitch.me/one, "options": {
    action = advance;
}, "timestamp": 1656559818238] [:]
2022-06-30 03:30:18 +0000 [Session] visit ["options": Turbo.VisitOptions(action: Turbo.VisitAction.advance, response: nil), "location": https://turbo-native-demo.glitch.me/one, "reload": false]
2022-06-30 03:30:18 +0000 [JavascriptVisit] startVisit https://turbo-native-demo.glitch.me/one [:]
2022-06-30 03:30:18 +0000 [Bridge] → window.turboNative.visitLocationWithOptionsAndRestorationIdentifier [Optional("https://turbo-native-demo.glitch.me/one"), Optional({
    action = advance;
}), nil] [:]
2022-06-30 03:30:18 +0000 [Bridge] ← visitStarted ["identifier": 6cd858b3-5a0c-4695-a5b0-48597a97ea1c, "hasCachedSnapshot": 0, "timestamp": 1656559818246] [:]
2022-06-30 03:30:18 +0000 [JavascriptVisit] didStartVisitWithIdentifier https://turbo-native-demo.glitch.me/one ["identifier": "6cd858b3-5a0c-4695-a5b0-48597a97ea1c", "hasCachedSnapshot": false]
2022-06-30 03:30:18 +0000 [Bridge] ← visitRequestStarted ["identifier": 6cd858b3-5a0c-4695-a5b0-48597a97ea1c, "timestamp": 1656559818248] [:]
2022-06-30 03:30:18 +0000 [JavascriptVisit] didFinishRequestForVisitWithIdentifier https://turbo-native-demo.glitch.me/one ["identifier": "6cd858b3-5a0c-4695-a5b0-48597a97ea1c", "date": 2022-06-30 03:30:18 +0000]
2022-06-30 03:30:18 +0000 [Bridge] = window.turboNative.visitLocationWithOptionsAndRestorationIdentifier evaluation complete [:]
2022-06-30 03:30:18 +0000 [Bridge] ← visitRequestCompleted ["identifier": 6cd858b3-5a0c-4695-a5b0-48597a97ea1c, "timestamp": 1656559818344] [:]
2022-06-30 03:30:18 +0000 [JavascriptVisit] didCompleteRequestForVisitWithIdentifier https://turbo-native-demo.glitch.me/one ["identifier": "6cd858b3-5a0c-4695-a5b0-48597a97ea1c"]
2022-06-30 03:30:18 +0000 [Bridge] ← visitRequestFinished ["identifier": 6cd858b3-5a0c-4695-a5b0-48597a97ea1c, "timestamp": 1656559818344] [:]
2022-06-30 03:30:18 +0000 [JavascriptVisit] didFinishRequestForVisitWithIdentifier https://turbo-native-demo.glitch.me/one ["identifier": "6cd858b3-5a0c-4695-a5b0-48597a97ea1c", "date": 2022-06-30 03:30:18 +0000]
2022-06-30 03:30:18 +0000 [Bridge] ← visitCompleted ["identifier": 6cd858b3-5a0c-4695-a5b0-48597a97ea1c, "restorationIdentifier": 4904de48-531e-42ec-b9e2-6ec8304108a9, "timestamp": 1656559818347] [:]
2022-06-30 03:30:18 +0000 [JavascriptVisit] didCompleteVisitWithIdentifier https://turbo-native-demo.glitch.me/one ["identifier": "6cd858b3-5a0c-4695-a5b0-48597a97ea1c", "restorationIdentifier": "4904de48-531e-42ec-b9e2-6ec8304108a9"]
2022-06-30 03:30:18 +0000 [Bridge] ← visitRendered ["identifier": 6cd858b3-5a0c-4695-a5b0-48597a97ea1c, "timestamp": 1656559818366] [:]
2022-06-30 03:30:18 +0000 [JavascriptVisit] didRenderForVisitWithIdentifier https://turbo-native-demo.glitch.me/one ["identifier": "6cd858b3-5a0c-4695-a5b0-48597a97ea1c"]
2022-06-30 03:30:20 +0000 [Session] visit ["location": https://turbo-native-demo.glitch.me, "options": Turbo.VisitOptions(action: Turbo.VisitAction.restore, response: nil), "reload": false]
2022-06-30 03:30:20 +0000 [JavascriptVisit] startVisit https://turbo-native-demo.glitch.me [:]
2022-06-30 03:30:20 +0000 [Bridge] → window.turboNative.visitLocationWithOptionsAndRestorationIdentifier [Optional("https://turbo-native-demo.glitch.me"), Optional({
    action = restore;
}), Optional("42918dac-ca08-4d87-ae88-d866b21e9e14")] [:]
2022-06-30 03:30:20 +0000 [Bridge] ← visitStarted ["identifier": a966548e-8e36-4b39-a039-e4a03ec27734, "hasCachedSnapshot": 1, "timestamp": 1656559820532] [:]
2022-06-30 03:30:20 +0000 [JavascriptVisit] didStartVisitWithIdentifier https://turbo-native-demo.glitch.me ["hasCachedSnapshot": true, "identifier": "a966548e-8e36-4b39-a039-e4a03ec27734"]
2022-06-30 03:30:20 +0000 [Bridge] = window.turboNative.visitLocationWithOptionsAndRestorationIdentifier evaluation complete [:]
2022-06-30 03:30:20 +0000 [Bridge] ← visitCompleted ["restorationIdentifier": 42918dac-ca08-4d87-ae88-d866b21e9e14, "identifier": a966548e-8e36-4b39-a039-e4a03ec27734, "timestamp": 1656559820533] [:]
2022-06-30 03:30:20 +0000 [JavascriptVisit] didCompleteVisitWithIdentifier https://turbo-native-demo.glitch.me ["restorationIdentifier": "42918dac-ca08-4d87-ae88-d866b21e9e14", "identifier": "a966548e-8e36-4b39-a039-e4a03ec27734"]
2022-06-30 03:30:20 +0000 [Bridge] ← visitRendered ["identifier": a966548e-8e36-4b39-a039-e4a03ec27734, "timestamp": 1656559820549] [:]
2022-06-30 03:30:20 +0000 [JavascriptVisit] didRenderForVisitWithIdentifier https://turbo-native-demo.glitch.me ["identifier": "a966548e-8e36-4b39-a039-e4a03ec27734"]
```