### PR TITLE
Expose a new `TurboLog.debugLoggingEnabled` API that apps can enable to see debug logs

### DIFF
--- a/Demo/AppDelegate.swift
+++ b/Demo/AppDelegate.swift
@@ -1,9 +1,14 @@
 import UIKit
+import Turbo
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        true
+        #if DEBUG
+        TurboLog.debugLoggingEnabled = true
+        #endif
+        
+        return true
     }
 
     // MARK: UISceneSession Lifecycle

--- a/Source/Logging.swift
+++ b/Source/Logging.swift
@@ -1,17 +1,22 @@
 import Foundation
 
+public struct TurboLog {
+    public static var debugLoggingEnabled = false
+}
+
 /// Simple function to help in debugging, a noop in Release builds
-func debugLog(_ text: String, _ arguments: [String: Any] = [:]) {
-    #if DEBUG
+func debugLog(_ message: String, _ arguments: [String: Any] = [:]) {
     let timestamp = Date()
     
-    print("\(timestamp) \(text) \(arguments)")
-    
-    #endif
+    log("\(timestamp) \(message) \(arguments)")
 }
 
 func debugPrint(_ message: String) {
-    #if DEBUG
-    print(message)
-    #endif
+    log(message)
+}
+
+private func log(_ message: String) {
+    if TurboLog.debugLoggingEnabled {
+        print(message)
+    }
 }


### PR DESCRIPTION
Address #21 through an explicit API.