### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,11 +3,9 @@
 To set up your development environment:
 
 1. Clone the repo
-2. Install the test dependencies
-3. Run the tests via Xcode
+1. Open the directory in Xcode to install Swift packages
 
-```bash
-$ bin/carthage.sh bootstrap --cache-builds --use-xcframeworks --platform ios
-```
+To run the test suite:
 
-Open `Turbo.xcodeproj` and run the tests via Product → Test or <kbd>⌘</kbd>+<kbd>U</kbd>
+1. Open the directory in Xcode
+1. Click Product → Test or <kbd>⌘</kbd>+<kbd>U</kbd>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing to turbo-ios
+
+To set up your development environment:
+
+1. Clone the repo
+2. Install the test dependencies
+3. Run the tests via Xcode
+
+```bash
+$ bin/carthage.sh bootstrap --cache-builds --use-xcframeworks --platform ios
+```
+
+Open `Turbo.xcodeproj` and run the tests via Product → Test or <kbd>⌘</kbd>+<kbd>U</kbd>

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The best way to get started with Turbo iOS to try out the demo app first to get 
 
 ## Contributing
 
+Read the [contributing guide](/CONTRIBUTING.md) to learn how to set up your development environment.
+
 Turbo iOS is open-source software, freely distributable under the terms of an [MIT-style license](LICENSE). The [source code is hosted on GitHub](https://github.com/hotwired/turbo-ios).
 Development is sponsored by [Basecamp](https://basecamp.com/).
 


### PR DESCRIPTION
This PR adds CONTRIBUTING.md and a note to the README. I never remember the Carthage command to get the tests running locally so hopefully this will help someone.

I left the "guide" intentionally sparse as I didn't want to make too many assumptions about how Basecamp wants to manage contributor expectations.