### PR TITLE
Lint and format code

### DIFF
--- a/Demo/AppDelegate.swift
+++ b/Demo/AppDelegate.swift
@@ -1,5 +1,5 @@
-import UIKit
 import Turbo
+import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -7,7 +7,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         #if DEBUG
         TurboLog.debugLoggingEnabled = true
         #endif
-        
+
         return true
     }
 

--- a/Demo/Navigation/TurboNavigationController.swift
+++ b/Demo/Navigation/TurboNavigationController.swift
@@ -6,37 +6,36 @@
 //
 
 import Foundation
-import UIKit
 import Turbo
+import UIKit
 
-class TurboNavigationController : UINavigationController {
-    
+class TurboNavigationController: UINavigationController {
     var session: Session!
     var modalSession: Session!
-    
+
     func push(url: URL) {
         let properties = session.pathConfiguration?.properties(for: url) ?? [:]
         route(url: url,
               options: VisitOptions(action: .advance),
               properties: properties)
     }
-    
+
     func route(url: URL, options: VisitOptions, properties: PathProperties) {
         // This is a simplified version of how you might build out the routing
         // and navigation functions of your app. In a real app, these would be separate objects
-        
+
         // Dismiss any modals when receiving a new navigation
         if presentedViewController != nil {
             dismiss(animated: true)
         }
-        
+
         // Special case of navigating home, issue a reload
         if url.path == "/", !viewControllers.isEmpty {
             popViewController(animated: false)
             session.reload()
             return
         }
-        
+
         // - Create view controller appropriate for url/properties
         // - Navigate to that with the correct presentation
         // - Initiate the visit with Turbo
@@ -47,20 +46,19 @@ class TurboNavigationController : UINavigationController {
 }
 
 extension TurboNavigationController {
-    
     private func isModal(_ properties: PathProperties) -> Bool {
         // For simplicity, we're using string literals for various keys and values of the path configuration
         // but most likely you'll want to define your own enums these properties
         let presentation = properties["presentation"] as? String
         return presentation == "modal"
     }
-    
+
     private func makeViewController(for url: URL, properties: PathProperties = [:]) -> UIViewController {
         // There are many options for determining how to map urls to view controllers
         // The demo uses the path configuration for determining which view controller and presentation
         // to use, but that's completely optional. You can use whatever logic you prefer to determine
         // how you navigate and route different URLs.
-        
+
         if let viewController = properties["view-controller"] as? String {
             switch viewController {
             case "numbers":
@@ -75,13 +73,13 @@ extension TurboNavigationController {
                 assertionFailure("Invalid view controller, defaulting to WebView")
             }
         }
-            
+
         return ViewController(url: url)
     }
-    
+
     private func navigate(to viewController: UIViewController, action: VisitAction, properties: PathProperties = [:], animated: Bool = true) {
         // We support three types of navigation in the app: advance, replace, and modal
-        
+
         if isModal(properties) {
             if viewController is UIAlertController {
                 present(viewController, animated: animated, completion: nil)
@@ -96,10 +94,10 @@ extension TurboNavigationController {
             pushViewController(viewController, animated: animated)
         }
     }
-    
+
     private func visit(viewController: UIViewController, with options: VisitOptions, modal: Bool = false) {
         guard let visitable = viewController as? Visitable else { return }
-        
+
         // Each Session corresponds to a single web view. A good rule of thumb
         // is to use a session per navigation stack. Here we're using a different session
         // when presenting a modal. We keep that around for any modal presentations so

--- a/Demo/NumbersViewController.swift
+++ b/Demo/NumbersViewController.swift
@@ -3,16 +3,15 @@ import UIKit
 /// A simple native table view controller to demonstrate loading non-Turbo screens
 /// for a visit proposal
 final class NumbersViewController: UITableViewController {
-    
     var url: URL!
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         title = "Numbers"
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: "Cell")
     }
-    
+
     override func numberOfSections(in tableView: UITableView) -> Int {
         1
     }
@@ -29,7 +28,7 @@ final class NumbersViewController: UITableViewController {
 
         return cell
     }
-    
+
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let turboNavController = navigationController as! TurboNavigationController
         turboNavController.push(url: url.appendingPathComponent("\(indexPath.row + 1)"))

--- a/Demo/ViewController.swift
+++ b/Demo/ViewController.swift
@@ -1,21 +1,21 @@
-import UIKit
 import Turbo
+import UIKit
 
 final class ViewController: VisitableViewController, ErrorPresenter {
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         if #available(iOS 14.0, *) {
             navigationItem.backButtonDisplayMode = .minimal
         }
-        
+
         view.backgroundColor = .systemBackground
-        
+
         if presentingViewController != nil {
             navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(dismissModal))
         }
     }
-    
+
     @objc func dismissModal() {
         dismiss(animated: true)
     }

--- a/Source/Logging.swift
+++ b/Source/Logging.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-public struct TurboLog {
+public enum TurboLog {
     public static var debugLoggingEnabled = false
 }
 
 /// Simple function to help in debugging, a noop in Release builds
 func debugLog(_ message: String, _ arguments: [String: Any] = [:]) {
     let timestamp = Date()
-    
+
     log("\(timestamp) \(message) \(arguments)")
 }
 

--- a/Source/Path Configuration/PathConfiguration.swift
+++ b/Source/Path Configuration/PathConfiguration.swift
@@ -9,13 +9,13 @@ public protocol PathConfigurationDelegate: AnyObject {
 
 public final class PathConfiguration {
     public weak var delegate: PathConfigurationDelegate?
-    
+
     /// Returns top-level settings: `{ settings: {} }`
     public private(set) var settings: [String: AnyHashable] = [:]
-    
+
     /// The list of rules from the configuration: `{ rules: [] }`
     public private(set) var rules: [PathRule] = []
-    
+
     /// Sources for this configuration, setting it will
     /// cause the configuration to be loaded from the new sources
     public var sources: [Source] = [] {
@@ -23,7 +23,7 @@ public final class PathConfiguration {
             load()
         }
     }
-    
+
     /// Multiple sources will be loaded in order
     /// Remote sources should be last since they're loaded async
     public init(sources: [Source] = []) {
@@ -35,12 +35,12 @@ public final class PathConfiguration {
     public subscript(path: String) -> PathProperties {
         properties(for: path)
     }
-    
+
     /// Convenience method for retrieving properties for url: configuration[url]
     public subscript(url: URL) -> PathProperties {
         properties(for: url)
     }
-    
+
     /// Returns a merged dictionary containing all the properties
     /// that match this url
     /// Note: currently only looks at path, not query, but most likely will
@@ -49,19 +49,19 @@ public final class PathConfiguration {
     public func properties(for url: URL) -> PathProperties {
         properties(for: url.path)
     }
-    
+
     /// Returns a merged dictionary containing all the properties
     /// that match this path
     public func properties(for path: String) -> PathProperties {
         var properties: PathProperties = [:]
-        
+
         for rule in rules where rule.match(path: path) {
             properties.merge(rule.properties) { _, new in new }
         }
-        
+
         return properties
     }
-    
+
     // MARK: - Loading
 
     private var loader: PathConfigurationLoader?
@@ -72,7 +72,7 @@ public final class PathConfiguration {
             self?.update(with: config)
         }
     }
-    
+
     private func update(with config: PathConfigurationDecoder) {
         // Update our internal state with the config from the loader
         settings = config.settings
@@ -87,8 +87,8 @@ extension PathConfiguration: Equatable {
     }
 }
 
-extension PathConfiguration {
-    public enum Source: Equatable {
+public extension PathConfiguration {
+    enum Source: Equatable {
         case data(Data)
         case file(URL)
         case server(URL)

--- a/Source/Path Configuration/PathConfigurationDecoder.swift
+++ b/Source/Path Configuration/PathConfigurationDecoder.swift
@@ -6,7 +6,7 @@ import Foundation
 struct PathConfigurationDecoder: Equatable {
     let settings: [String: AnyHashable]
     let rules: [PathRule]
-    
+
     init(settings: [String: AnyHashable] = [:], rules: [PathRule] = []) {
         self.settings = settings
         self.rules = rules
@@ -19,10 +19,10 @@ extension PathConfigurationDecoder {
         guard let rulesArray = json["rules"] as? [[String: AnyHashable]] else {
             throw JSONDecodingError.invalidJSON
         }
-        
+
         let rules = try rulesArray.compactMap(PathRule.init)
         let settings = (json["settings"] as? [String: AnyHashable]) ?? [:]
-        
+
         self.init(settings: settings, rules: rules)
     }
 }

--- a/Source/Path Configuration/PathConfigurationLoader.swift
+++ b/Source/Path Configuration/PathConfigurationLoader.swift
@@ -7,14 +7,14 @@ final class PathConfigurationLoader {
     private let configurationCacheFilename = "path-configuration.json"
     private let sources: [PathConfiguration.Source]
     private var completionHandler: PathConfigurationLoaderCompletionHandler?
-    
+
     init(sources: [PathConfiguration.Source]) {
         self.sources = sources
     }
-    
+
     func load(then completion: @escaping PathConfigurationLoaderCompletionHandler) {
         completionHandler = completion
-        
+
         for source in sources {
             switch source {
             case .data(let data):
@@ -26,47 +26,47 @@ final class PathConfigurationLoader {
             }
         }
     }
-    
+
     // MARK: - Server
-    
+
     private func download(from url: URL) {
         precondition(!url.isFileURL, "URL provided for server is a file url")
-        
+
         // Immediately load most recent cached version if available
         if let data = cachedData() {
             loadData(data)
         }
-        
+
         URLSession.shared.dataTask(with: url) { [weak self] data, response, error in
             guard let data = data,
-                let httpResponse = response as? HTTPURLResponse,
-                httpResponse.statusCode == 200
+                  let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200
             else {
                 debugPrint("[path-configuration] *** error - invalid response or data: \(String(describing: response)), error: \(String(describing: error))")
                 return
             }
-            
+
             self?.loadData(data, cache: true)
         }.resume()
     }
-    
+
     // MARK: - Caching
-    
+
     private func cacheRemoteData(_ data: Data) {
         createCacheDirectoryIfNeeded()
-        
+
         do {
             try data.write(to: configurationCacheURL)
         } catch {
             debugPrint("[path-configuration-loader] error caching file error: \(error)")
         }
     }
-    
+
     private func cachedData() -> Data? {
         guard FileManager.default.fileExists(atPath: configurationCacheURL.path) else {
             return nil
         }
-        
+
         do {
             return try Data(contentsOf: configurationCacheURL)
         } catch {
@@ -74,31 +74,31 @@ final class PathConfigurationLoader {
             return nil
         }
     }
-    
+
     private func createCacheDirectoryIfNeeded() {
         guard !FileManager.default.fileExists(atPath: turboCacheDirectoryURL.path) else { return }
-        
+
         do {
             try FileManager.default.createDirectory(at: turboCacheDirectoryURL, withIntermediateDirectories: false, attributes: nil)
         } catch {
             debugPrint("[path-configuration-loader] *** error creating cache directory: \(error)")
         }
     }
-    
+
     private var turboCacheDirectoryURL: URL {
         let directory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
         return directory.appendingPathComponent(cacheDirectory)
     }
-    
+
     var configurationCacheURL: URL {
         turboCacheDirectoryURL.appendingPathComponent(configurationCacheFilename)
     }
-    
+
     // MARK: - File
-    
+
     private func loadFile(_ url: URL) {
         precondition(url.isFileURL, "URL provided for file is not a file url")
-        
+
         do {
             let data = try Data(contentsOf: url)
             loadData(data)
@@ -106,30 +106,30 @@ final class PathConfigurationLoader {
             debugPrint("[path-configuration] *** error loading configuration from file: \(url), error: \(error)")
         }
     }
-    
+
     // MARK: - Data
-    
+
     private func loadData(_ data: Data, cache: Bool = false) {
         do {
             guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
                 throw JSONDecodingError.invalidJSON
             }
-            
+
             let config = try PathConfigurationDecoder(json: json)
-            
+
             if cache {
                 // Only cache once we ensure we have valid data
                 cacheRemoteData(data)
             }
-            
+
             updateHandler(with: config)
         } catch {
             debugPrint("[path-configuration] *** error decoding path configuration: \(error)")
         }
     }
-    
+
     // MARK: - Delegate
-    
+
     private func updateHandler(with config: PathConfigurationDecoder) {
         if Thread.isMainThread {
             completionHandler?(config)

--- a/Source/Path Configuration/PathRule.swift
+++ b/Source/Path Configuration/PathRule.swift
@@ -3,32 +3,32 @@ import Foundation
 public struct PathRule: Equatable {
     /// Array of regular expressions to match against
     public let patterns: [String]
-    
+
     /// The properties to apply for matches
     public let properties: PathProperties
-    
+
     /// Convenience method to retrieve a String value for a key
     /// Access `properties` directly to get a different type
     public subscript(key: String) -> String? {
         properties[key] as? String
     }
-    
+
     init(patterns: [String], properties: PathProperties) {
         self.patterns = patterns
         self.properties = properties
     }
-    
+
     /// Returns true if any pattern in this rule matches `path`
     public func match(path: String) -> Bool {
         for pattern in patterns {
             guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
-            
-            let range = NSRange(path.startIndex..<path.endIndex, in: path)
+
+            let range = NSRange(path.startIndex ..< path.endIndex, in: path)
             if regex.numberOfMatches(in: path, range: range) > 0 {
                 return true
             }
         }
-        
+
         return false
     }
 }
@@ -36,11 +36,11 @@ public struct PathRule: Equatable {
 extension PathRule {
     init(json: [String: Any]) throws {
         guard let patterns = json["patterns"] as? [String],
-            let properties = json["properties"] as? [String: AnyHashable]
+              let properties = json["properties"] as? [String: AnyHashable]
         else {
             throw JSONDecodingError.invalidJSON
         }
-        
+
         self.init(patterns: patterns, properties: properties)
     }
 }

--- a/Source/Session/SessionDelegate.swift
+++ b/Source/Session/SessionDelegate.swift
@@ -3,7 +3,7 @@ import UIKit
 public protocol SessionDelegate: AnyObject {
     func session(_ session: Session, didProposeVisit proposal: VisitProposal)
     func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error)
-    
+
     func session(_ session: Session, openExternalURL url: URL)
     func session(_ session: Session, didReceiveAuthenticationChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
 
@@ -20,16 +20,16 @@ public extension SessionDelegate {
     func sessionDidLoadWebView(_ session: Session) {
         session.webView.navigationDelegate = session
     }
-    
+
     func session(_ session: Session, openExternalURL url: URL) {
         UIApplication.shared.open(url)
     }
-    
+
     func sessionDidStartRequest(_ session: Session) {}
     func sessionDidFinishRequest(_ session: Session) {}
     func sessionDidStartFormSubmission(_ session: Session) {}
     func sessionDidFinishFormSubmission(_ session: Session) {}
-    
+
     func session(_ session: Session, didReceiveAuthenticationChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         completionHandler(.performDefaultHandling, nil)
     }

--- a/Source/TurboError.swift
+++ b/Source/TurboError.swift
@@ -7,7 +7,7 @@ public enum TurboError: LocalizedError, Equatable {
     case contentTypeMismatch
     case pageLoadFailure
     case http(statusCode: Int)
-    
+
     init(statusCode: Int) {
         switch statusCode {
         case 0:
@@ -20,7 +20,7 @@ public enum TurboError: LocalizedError, Equatable {
             self = .http(statusCode: statusCode)
         }
     }
-    
+
     public var errorDescription: String? {
         switch self {
         case .networkFailure:

--- a/Source/Visit/ColdBootVisit.swift
+++ b/Source/Visit/ColdBootVisit.swift
@@ -24,7 +24,7 @@ final class ColdBootVisit: Visit {
 
     override func cancelVisit() {
         log("cancelVisit")
-        
+
         removeNavigationDelegate()
         webView.stopLoading()
         finishRequest()
@@ -32,14 +32,14 @@ final class ColdBootVisit: Visit {
 
     override func completeVisit() {
         log("completeVisit")
-        
+
         removeNavigationDelegate()
         delegate?.visitDidInitializeWebView(self)
     }
 
     override func failVisit() {
         log("failVisit")
-        
+
         removeNavigationDelegate()
         finishRequest()
     }
@@ -48,7 +48,7 @@ final class ColdBootVisit: Visit {
         guard webView.navigationDelegate === self else { return }
         webView.navigationDelegate = nil
     }
-    
+
     private func log(_ name: String) {
         debugLog("[ColdBootVisit] \(name) \(location.absoluteString)")
     }
@@ -74,14 +74,14 @@ extension ColdBootVisit: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse, decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
         if let httpResponse = navigationResponse.response as? HTTPURLResponse {
-            if httpResponse.statusCode >= 200 && httpResponse.statusCode < 300 {
+            if httpResponse.statusCode >= 200, httpResponse.statusCode < 300 {
                 decisionHandler(.allow)
             } else {
                 decisionHandler(.cancel)
                 fail(with: TurboError.http(statusCode: httpResponse.statusCode))
             }
         } else {
-            if (navigationResponse.response.url?.scheme == "blob") {
+            if navigationResponse.response.url?.scheme == "blob" {
                 decisionHandler(.allow)
             } else {
                 decisionHandler(.cancel)
@@ -99,7 +99,7 @@ extension ColdBootVisit: WKNavigationDelegate {
         guard navigation == self.navigation else { return }
         fail(with: error)
     }
-    
+
     func webView(_ webView: WKWebView, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         delegate?.visit(self, didReceiveAuthenticationChallenge: challenge, completionHandler: completionHandler)
     }

--- a/Source/Visit/Visit.swift
+++ b/Source/Visit/Visit.swift
@@ -16,10 +16,10 @@ class Visit: NSObject {
     let bridge: WebViewBridge
     var webView: WKWebView { bridge.webView }
     let location: URL
-    
+
     var hasCachedSnapshot: Bool = false
     private(set) var state: VisitState
-    
+
     init(visitable: Visitable, options: VisitOptions, bridge: WebViewBridge) {
         self.visitable = visitable
         self.location = visitable.visitableURL!
@@ -38,20 +38,20 @@ class Visit: NSObject {
 
     func cancel() {
         guard state == .started else { return }
-        
+
         state = .canceled
         cancelVisit()
     }
 
     func complete() {
         guard state == .started else { return }
-        
+
         if !requestFinished {
             finishRequest()
         }
-        
+
         state = .completed
-        
+
         completeVisit()
         delegate?.visitDidComplete(self)
         delegate?.visitDidFinish(self)
@@ -79,14 +79,14 @@ class Visit: NSObject {
 
     func startRequest() {
         guard !requestStarted else { return }
-        
+
         requestStarted = true
         delegate?.visitRequestDidStart(self)
     }
 
     func finishRequest() {
         guard requestStarted, !requestFinished else { return }
-        
+
         requestFinished = true
         delegate?.visitRequestDidFinish(self)
     }

--- a/Source/Visit/VisitOptions.swift
+++ b/Source/Visit/VisitOptions.swift
@@ -3,12 +3,12 @@ import Foundation
 public struct VisitOptions: Codable, JSONCodable {
     public let action: VisitAction
     public let response: VisitResponse?
-        
+
     public init(action: VisitAction = .advance, response: VisitResponse? = nil) {
         self.action = action
         self.response = response
     }
-    
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.action = try container.decodeIfPresent(VisitAction.self, forKey: .action) ?? .advance

--- a/Source/Visit/VisitProposal.swift
+++ b/Source/Visit/VisitProposal.swift
@@ -4,7 +4,7 @@ public struct VisitProposal {
     public let url: URL
     public let options: VisitOptions
     public let properties: PathProperties
-    
+
     public init(url: URL, options: VisitOptions, properties: PathProperties = [:]) {
         self.url = url
         self.options = options

--- a/Source/Visit/VisitResponse.swift
+++ b/Source/Visit/VisitResponse.swift
@@ -3,15 +3,15 @@ import Foundation
 public struct VisitResponse: Codable {
     public let statusCode: Int
     public let responseHTML: String?
-    
+
     public init(statusCode: Int, responseHTML: String? = nil) {
         self.statusCode = statusCode
         self.responseHTML = responseHTML
     }
-    
+
     public var isSuccessful: Bool {
         switch statusCode {
-        case 200...299:
+        case 200 ... 299:
             return true
         default:
             return false

--- a/Source/Visitable/Visitable.swift
+++ b/Source/Visitable/Visitable.swift
@@ -10,10 +10,10 @@ public protocol VisitableDelegate: AnyObject {
 
 public protocol Visitable: AnyObject {
     var visitableViewController: UIViewController { get }
-    var visitableDelegate: VisitableDelegate? { get set } 
+    var visitableDelegate: VisitableDelegate? { get set }
     var visitableView: VisitableView! { get }
     var visitableURL: URL! { get }
-    
+
     func visitableDidRender()
     func showVisitableActivityIndicator()
     func hideVisitableActivityIndicator()
@@ -23,7 +23,7 @@ extension Visitable {
     public func reloadVisitable() {
         visitableDelegate?.visitableDidRequestReload(self)
     }
-    
+
     public func showVisitableActivityIndicator() {
         visitableView.showActivityIndicator()
     }
@@ -69,8 +69,8 @@ extension Visitable {
     }
 }
 
-extension Visitable where Self: UIViewController {
-    public var visitableViewController: UIViewController {
+public extension Visitable where Self: UIViewController {
+    var visitableViewController: UIViewController {
         self
     }
 }

--- a/Source/Visitable/VisitableView.swift
+++ b/Source/Visitable/VisitableView.swift
@@ -2,12 +2,12 @@ import UIKit
 import WebKit
 
 open class VisitableView: UIView {
-    public override init(frame: CGRect) {
+    override public init(frame: CGRect) {
         super.init(frame: frame)
         setup()
     }
-    
-    required public init?(coder aDecoder: NSCoder) {
+
+    public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         setup()
     }
@@ -65,7 +65,7 @@ open class VisitableView: UIView {
 
     private func installRefreshControl() {
         guard let scrollView = webView?.scrollView, allowsPullToRefresh else { return }
-        
+
         #if !targetEnvironment(macCatalyst)
         scrollView.addSubview(refreshControl)
         #endif
@@ -84,13 +84,13 @@ open class VisitableView: UIView {
 
     open lazy var activityIndicatorView: UIActivityIndicatorView = {
         let view: UIActivityIndicatorView
-        
+
         if #available(iOS 13.0, *) {
             view = UIActivityIndicatorView(style: .medium)
         } else {
             view = UIActivityIndicatorView(style: .white)
         }
-        
+
         view.translatesAutoresizingMaskIntoConstraints = false
         view.color = UIColor.gray
         view.hidesWhenStopped = true
@@ -132,7 +132,7 @@ open class VisitableView: UIView {
     }
 
     open func updateScreenshot() {
-        guard !isShowingScreenshot, let webView = self.webView, let screenshot = webView.snapshotView(afterScreenUpdates: false) else { return }
+        guard !isShowingScreenshot, let webView = webView, let screenshot = webView.snapshotView(afterScreenUpdates: false) else { return }
 
         screenshotView?.removeFromSuperview()
         screenshot.translatesAutoresizingMaskIntoConstraints = false
@@ -145,7 +145,7 @@ open class VisitableView: UIView {
             screenshot.heightAnchor.constraint(equalToConstant: screenshot.bounds.size.height)
         ])
 
-        screenshotView = screenshot        
+        screenshotView = screenshot
     }
 
     open func showScreenshot() {
@@ -166,7 +166,7 @@ open class VisitableView: UIView {
     }
 
     // MARK: - Constraints
-    
+
     private func addFillConstraints(for view: UIView) {
         NSLayoutConstraint.activate([
             view.leadingAnchor.constraint(equalTo: leadingAnchor),

--- a/Source/Visitable/VisitableViewController.swift
+++ b/Source/Visitable/VisitableViewController.swift
@@ -8,21 +8,21 @@ open class VisitableViewController: UIViewController, Visitable {
         self.init()
         self.visitableURL = url
     }
-    
+
     // MARK: View Lifecycle
 
-    open override func viewDidLoad() {
+    override open func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = UIColor.white
         installVisitableView()
     }
 
-    open override func viewWillAppear(_ animated: Bool) {
+    override open func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         visitableDelegate?.visitableViewWillAppear(self)
     }
 
-    open override func viewDidAppear(_ animated: Bool) {
+    override open func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         visitableDelegate?.visitableViewDidAppear(self)
     }
@@ -32,15 +32,15 @@ open class VisitableViewController: UIViewController, Visitable {
     open func visitableDidRender() {
         title = visitableView.webView?.title
     }
-    
+
     open func showVisitableActivityIndicator() {
         visitableView.showActivityIndicator()
     }
-    
+
     open func hideVisitableActivityIndicator() {
         visitableView.hideActivityIndicator()
     }
-    
+
     // MARK: Visitable View
 
     open private(set) lazy var visitableView: VisitableView! = {

--- a/Source/WebView/JSON.swift
+++ b/Source/WebView/JSON.swift
@@ -22,7 +22,7 @@ extension JSONCodable {
             return nil
         }
     }
-    
+
     func toJSON() -> Any {
         do {
             let encoder = JSONEncoder()

--- a/Source/WebView/JavaScriptExpression.swift
+++ b/Source/WebView/JavaScriptExpression.swift
@@ -3,17 +3,17 @@ import Foundation
 struct JavaScriptExpression {
     let function: String
     let arguments: [Any?]
-    
+
     var string: String? {
         guard let encodedArguments = encode(arguments: arguments) else { return nil }
         return "\(function)(\(encodedArguments))"
     }
-    
+
     var wrappedString: String? {
         guard let encodedArguments = encode(arguments: arguments) else { return nil }
         return wrap(function: function, encodedArguments: encodedArguments)
     }
-    
+
     private func wrap(function: String, encodedArguments arguments: String) -> String {
         """
         (function(result) {
@@ -23,20 +23,21 @@ struct JavaScriptExpression {
             result.error = error.toString()
             result.stack = error.stack
           }
-        
+
           return result
         })({})
         """
     }
-    
+
     private func encode(arguments: [Any?]) -> String? {
         let arguments = arguments.map { $0 == nil ? NSNull() : $0! }
-        
+
         guard let data = try? JSONSerialization.data(withJSONObject: arguments),
-            let string = String(data: data, encoding: .utf8) else {
-                return nil
+              let string = String(data: data, encoding: .utf8)
+        else {
+            return nil
         }
-        
+
         // Strip leading/trailing [] so we have a list of arguments suitable for inserting between parens
         return String(string.dropFirst().dropLast())
     }

--- a/Source/WebView/ScriptMessage.swift
+++ b/Source/WebView/ScriptMessage.swift
@@ -7,12 +7,12 @@ struct ScriptMessage {
     var identifier: String? {
         data["identifier"] as? String
     }
-    
+
     /// Milliseconds since unix epoch as provided by JavaScript Date.now()
     var timestamp: TimeInterval {
         data["timestamp"] as? TimeInterval ?? 0
     }
-    
+
     var date: Date {
         Date(timeIntervalSince1970: timestamp / 1000.0)
     }
@@ -20,7 +20,7 @@ struct ScriptMessage {
     var restorationIdentifier: String? {
         data["restorationIdentifier"] as? String
     }
-   
+
     var location: URL? {
         guard let locationString = data["location"] as? String else { return nil }
         return URL(string: locationString)
@@ -35,13 +35,13 @@ struct ScriptMessage {
 extension ScriptMessage {
     init?(message: WKScriptMessage) {
         guard let body = message.body as? [String: Any],
-            let rawName = body["name"] as? String,
-            let name = Name(rawValue: rawName),
-            let data = body["data"] as? [String: Any]
+              let rawName = body["name"] as? String,
+              let name = Name(rawValue: rawName),
+              let data = body["data"] as? [String: Any]
         else {
             return nil
         }
-        
+
         self.init(name: name, data: data)
     }
 }

--- a/Source/WebView/ScriptMessageHandler.swift
+++ b/Source/WebView/ScriptMessageHandler.swift
@@ -7,11 +7,11 @@ protocol ScriptMessageHandlerDelegate: AnyObject {
 // This class prevents retain cycle caused by WKUserContentController
 class ScriptMessageHandler: NSObject, WKScriptMessageHandler {
     weak var delegate: ScriptMessageHandlerDelegate?
-    
+
     init(delegate: ScriptMessageHandlerDelegate?) {
         self.delegate = delegate
     }
-    
+
     func userContentController(_ userContentController: WKUserContentController, didReceive scriptMessage: WKScriptMessage) {
         delegate?.scriptMessageHandlerDidReceiveMessage(scriptMessage)
     }

--- a/Tests/ColdBootVisitSpec.swift
+++ b/Tests/ColdBootVisitSpec.swift
@@ -1,7 +1,7 @@
-import Quick
 import Nimble
-import WebKit
+import Quick
 @testable import Turbo
+import WebKit
 
 class ColdBootVisitSpec: QuickSpec {
     override func spec() {

--- a/Tests/JavaScriptExpressionSpec.swift
+++ b/Tests/JavaScriptExpressionSpec.swift
@@ -1,5 +1,5 @@
-import Quick
 import Nimble
+import Quick
 @testable import Turbo
 
 class JavaScriptExpressionSpec: QuickSpec {
@@ -8,12 +8,12 @@ class JavaScriptExpressionSpec: QuickSpec {
             it("converts function and arguments into a valid expression") {
                 let expression = JavaScriptExpression(function: "console.log", arguments: [])
                 expect(expression.string) == "console.log()"
-                
+
                 let expression2 = JavaScriptExpression(function: "console.log", arguments: ["one", nil, 2])
                 expect(expression2.string) == "console.log(\"one\",null,2)"
             }
         }
-        
+
         describe(".wrapped") {
             it("wraps expression in IIFE and try/catch") {
                 let expression = JavaScriptExpression(function: "console.log", arguments: [])
@@ -25,11 +25,11 @@ class JavaScriptExpressionSpec: QuickSpec {
                     result.error = error.toString()
                     result.stack = error.stack
                   }
-                
+
                   return result
                 })({})
                 """
-                
+
                 expect(expression.wrappedString) == expected
             }
         }

--- a/Tests/JavaScriptVisitSpec.swift
+++ b/Tests/JavaScriptVisitSpec.swift
@@ -1,8 +1,6 @@
-import Quick
 import Nimble
+import Quick
 
 class JavaScriptVisitSpec: QuickSpec {
-    override func spec() {
-
-    }
+    override func spec() {}
 }

--- a/Tests/PathConfigurationLoaderSpec.swift
+++ b/Tests/PathConfigurationLoaderSpec.swift
@@ -1,100 +1,100 @@
-import XCTest
-import Quick
 import Nimble
 import OHHTTPStubs
+import Quick
 @testable import Turbo
+import XCTest
 
 class PathConfigurationLoaderSpec: QuickSpec {
     override func spec() {
         let serverURL = URL(string: "http://turbo.test/configuration.json")!
         let fileURL = Bundle(for: type(of: self)).url(forResource: "test-configuration", withExtension: "json")!
-        
+
         describe("load") {
             context("data") {
                 it("automatically loads from passed in data and calls the handler") {
                     let data = try! Data(contentsOf: fileURL)
                     let loader = PathConfigurationLoader(sources: [.data(data)])
-                    
-                    var config: PathConfigurationDecoder? = nil
+
+                    var config: PathConfigurationDecoder?
                     loader.load { conf in
                         config = conf
                     }
-                    
+
                     expect(config).toEventuallyNot(beNil())
                     expect(config!.rules.count) == 4
                 }
             }
-            
+
             context("file") {
                 it("automatically loads from the local file and calls the handler") {
                     let loader = PathConfigurationLoader(sources: [.file(fileURL)])
-                    
-                    var config: PathConfigurationDecoder? = nil
+
+                    var config: PathConfigurationDecoder?
                     loader.load { conf in
                         config = conf
                     }
-                    
+
                     expect(config).toNot(beNil())
                     expect(config!.rules.count) == 4
                 }
             }
-            
+
             context("server") {
                 var loader: PathConfigurationLoader!
-                
+
                 beforeEach {
                     loader = PathConfigurationLoader(sources: [.server(serverURL)])
                     stub(condition: { _ in true }) { _ in
                         let json = ["rules": [["patterns": ["/new"], "properties": ["presentation": "test"]]]]
                         return HTTPStubsResponse(jsonObject: json, statusCode: 200, headers: [:])
                     }
-                    
+
                     clearCache(loader.configurationCacheURL)
                 }
-                
+
                 it("automatically downloads the file and calls the handler") {
-                    var config: PathConfigurationDecoder? = nil
+                    var config: PathConfigurationDecoder?
                     loader.load { conf in
                         config = conf
                     }
-                    
+
                     expect(config).toEventuallyNot(beNil())
                     expect(config!.rules.count) == 1
                 }
-                
+
                 it("caches the file") {
                     var handlerCalled = false
-                    loader.load { rs in
+                    loader.load { _ in
                         handlerCalled = true
                     }
-                    
+
                     expect(handlerCalled).toEventually(beTrue())
                     expect(FileManager.default.fileExists(atPath: loader!.configurationCacheURL.path)) == true
                 }
             }
-            
+
             context("when file and remote") {
                 it("loads the file url and the remote url") {
                     let loader = PathConfigurationLoader(sources: [.file(fileURL), .server(serverURL)])
                     clearCache(loader.configurationCacheURL)
-                    
+
                     stub(condition: { _ in true }) { _ in
                         let json = ["rules": [["patterns": ["/new"], "properties": ["presentation": "test"]]]]
                         return HTTPStubsResponse(jsonObject: json, statusCode: 200, headers: [:])
                     }
-                    
+
                     var handlerCalledTimes = 0
-                    
+
                     loader.load { config in
                         if handlerCalledTimes == 0 {
                             expect(config.rules.count) == 4
                         } else {
                             expect(config.rules.count) == 1
                         }
-                        
+
                         handlerCalledTimes += 1
                     }
-                    
+
                     expect(handlerCalledTimes).toEventually(equal(2))
                 }
             }

--- a/Tests/PathConfigurationSpec.swift
+++ b/Tests/PathConfigurationSpec.swift
@@ -1,24 +1,24 @@
-import Quick
 import Nimble
+import Quick
 @testable import Turbo
 
 class PathConfigurationSpec: QuickSpec {
     override func spec() {
         let fileURL = Bundle(for: type(of: self)).url(forResource: "test-configuration", withExtension: "json")!
         var configuration: PathConfiguration!
-        
+
         beforeEach {
             configuration = PathConfiguration(sources: [.file(fileURL)])
             expect(configuration.rules.count).toEventually(beGreaterThan(0))
         }
-        
+
         describe("init") {
             it("automatically loads the configuration from the specified location") {
                 expect(configuration.settings.count) == 2
                 expect(configuration.rules.count) == 4
             }
         }
-        
+
         describe("settings") {
             it("returns current settings") {
                 expect(configuration.settings) == [
@@ -36,28 +36,28 @@ class PathConfigurationSpec: QuickSpec {
                     ]
                 }
             }
-            
+
             context("when path matches multiple rules") {
                 it("merges properties") {
-                    expect(configuration.properties(for: "/new")) ==  [
+                    expect(configuration.properties(for: "/new")) == [
                         "context": "modal",
                         "background_color": "black"
                     ]
-                    
-                    expect(configuration.properties(for: "/edit")) ==  [
+
+                    expect(configuration.properties(for: "/edit")) == [
                         "context": "modal",
                         "background_color": "white"
                     ]
                 }
             }
-            
+
             context("when no match") {
                 it("returns empty properties") {
                     expect(configuration.properties(for: "/missing")) == [:]
                 }
             }
         }
-        
+
         describe("subscript") {
             it("is a convenience method for properties(for path)") {
                 expect(configuration.properties(for: "/new")) == configuration["/new"]
@@ -80,15 +80,15 @@ class PathConfigSpec: QuickSpec {
                         let data = try Data(contentsOf: fileURL)
                         let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
                         let config = try PathConfigurationDecoder(json: json)
-                       
-                       expect(config.settings.count) == 2
-                       expect(config.rules.count) == 4
+
+                        expect(config.settings.count) == 2
+                        expect(config.rules.count) == 4
                     } catch {
                         fail("Error decoding from JSON: \(error)")
                     }
                 }
             }
-            
+
             context("with missing rules key") {
                 it("fails to decode") {
                     do {
@@ -102,4 +102,3 @@ class PathConfigSpec: QuickSpec {
         }
     }
 }
-

--- a/Tests/PathRuleSpec.swift
+++ b/Tests/PathRuleSpec.swift
@@ -1,40 +1,40 @@
-import XCTest
-import Quick
 import Nimble
+import Quick
 @testable import Turbo
+import XCTest
 
 class PathRuleSpec: QuickSpec {
     override func spec() {
         describe("subscript") {
             it("returns a String value for key") {
                 let rule = PathRule(patterns: ["^/new$"], properties: ["color": "blue", "modal": false])
-                
+
                 expect(rule["color"]) == "blue"
                 expect(rule["modal"]).to(beNil())
             }
         }
-        
+
         describe(".match") {
             context("when path matches single pattern") {
                 it("returns true") {
                     let rule = PathRule(patterns: ["^/new$"], properties: [:])
-                    
+
                     expect(rule.match(path: "/new")) == true
                 }
             }
-            
+
             context("when path matches any pattern in array") {
                 it("returns true") {
                     let rule = PathRule(patterns: ["^/new$", "^/edit"], properties: [:])
-                    
+
                     expect(rule.match(path: "/edit/1")) == true
                 }
             }
-            
+
             context("when path doesn't match any patterns") {
                 it("returns false") {
                     let rule = PathRule(patterns: ["^/new/bar"], properties: [:])
-                    
+
                     expect(rule.match(path: "/new")) == false
                     expect(rule.match(path: "foo")) == false
                 }

--- a/Tests/ScriptMessageSpec.swift
+++ b/Tests/ScriptMessageSpec.swift
@@ -1,8 +1,8 @@
+import Nimble
+import Quick
+@testable import Turbo
 import WebKit
 import XCTest
-import Quick
-import Nimble
-@testable import Turbo
 
 class ScriptMessageSpec: QuickSpec {
     override func spec() {
@@ -11,12 +11,12 @@ class ScriptMessageSpec: QuickSpec {
                 it("returns message") {
                     let data: [String: Any] = ["identifier": "123", "restorationIdentifier": "abc", "options": ["action": "advance"], "location": "http://turbo.test"]
                     let script = FakeScriptMessage(body: ["name": "pageLoaded", "data": data])
-                    
+
                     guard let message = ScriptMessage(message: script) else {
                         fail("Error parsing script message")
                         return
                     }
-                    
+
                     expect(message.name) == .pageLoaded
                     expect(message.identifier) == "123"
                     expect(message.restorationIdentifier) == "abc"
@@ -24,29 +24,29 @@ class ScriptMessageSpec: QuickSpec {
                     expect(message.location) == URL(string: "http://turbo.test")!
                 }
             }
-            
+
             context("with invalid body") {
                 it("returns nil") {
                     let script = FakeScriptMessage(body: "foo")
-                    
+
                     let message = ScriptMessage(message: script)
                     expect(message).to(beNil())
                 }
             }
-            
+
             context("with invalid name") {
                 it("returns nil") {
                     let script = FakeScriptMessage(body: ["name": "foobar"])
-                    
+
                     let message = ScriptMessage(message: script)
                     expect(message).to(beNil())
                 }
             }
-            
+
             context("with missing data") {
                 it("returns nil") {
                     let script = FakeScriptMessage(body: ["name": "pageLoaded"])
-                    
+
                     let message = ScriptMessage(message: script)
                     expect(message).to(beNil())
                 }
@@ -60,9 +60,9 @@ private class FakeScriptMessage: WKScriptMessage {
     override var body: Any {
         return actualBody
     }
-    
+
     var actualBody: Any
-    
+
     init(body: Any) {
         self.actualBody = body
     }

--- a/Tests/SessionSpec.swift
+++ b/Tests/SessionSpec.swift
@@ -1,9 +1,9 @@
+import GCDWebServers
+import Nimble
+import Quick
+@testable import Turbo
 import WebKit
 import XCTest
-import Quick
-import Nimble
-import GCDWebServers
-@testable import Turbo
 
 private let timeout = DispatchTimeInterval.seconds(15)
 
@@ -13,153 +13,153 @@ class SessionSpec: QuickSpec {
     override func spec() {
         var session: Session!
         var sessionDelegate: TestSessionDelegate!
-        
+
         beforeSuite {
             self.startServer()
         }
-        
+
         afterSuite {
             self.stopServer()
         }
-        
+
         beforeEach {
             sessionDelegate = TestSessionDelegate()
-            
+
             let configuration = WKWebViewConfiguration()
             configuration.applicationNameForUserAgent = "Turbo iOS Test/1.0"
             session = Session(webViewConfiguration: configuration)
             session.delegate = sessionDelegate
         }
-        
+
         afterEach {
             session.webView.configuration.userContentController.removeScriptMessageHandler(forName: "turbo")
         }
-        
+
         describe("init") {
             it("initializes web view with configuration") {
                 expect(session.webView.configuration.applicationNameForUserAgent) == "Turbo iOS Test/1.0"
             }
         }
-        
+
         describe("cold boot visit") {
             it("makes the session the visitable delegate") {
                 let visitable = TestVisitable(url: self.url("/"))
                 expect(visitable.visitableDelegate).to(beNil())
-                
+
                 session.visit(visitable)
                 expect(visitable.visitableDelegate) === session
             }
-            
+
             it("calls start request") {
                 let visitable = TestVisitable(url: self.url("/"))
                 session.visit(visitable)
-                
+
                 expect(sessionDelegate.sessionDidStartRequestCalled).toEventually(beTrue(), timeout: timeout)
             }
-            
+
             context("when visit succeeds") {
                 beforeEach {
                     let visitable = TestVisitable(url: self.url("/"))
                     session.visit(visitable)
                 }
-                
+
                 it("calls sessionDidLoadWebView delegate method") {
                     expect(sessionDelegate.sessionDidLoadWebViewCalled).toEventually(beTrue(), timeout: timeout)
                     expect(sessionDelegate.sessionDidFailRequestCalled) == false
                 }
-                
+
                 it("calls sessionDidFinishRequest delegate method") {
                     expect(sessionDelegate.sessionDidFinishRequestCalled).toEventually(beTrue(), timeout: timeout)
                     expect(sessionDelegate.sessionDidFailRequestCalled) == false
                 }
-                
+
                 it("configures JavaScript bridge") {
                     expect(sessionDelegate.sessionDidLoadWebViewCalled).toEventually(beTrue(), timeout: timeout)
 
                     waitUntil { done in
-                        session.webView.evaluateJavaScript("Turbo.navigator.adapter == window.turboNative") { result, error in
+                        session.webView.evaluateJavaScript("Turbo.navigator.adapter == window.turboNative") { result, _ in
                             XCTAssertEqual(result as? Bool, true)
                             done()
                         }
                     }
                 }
             }
-            
+
             context("when visit fails from http error") {
                 beforeEach {
                     let visitable = TestVisitable(url: self.url("/invalid"))
                     session.visit(visitable)
                 }
-                
+
                 it("calls sessionDidFailRequest delegate method") {
                     expect(sessionDelegate.sessionDidFailRequestCalled).toEventually(beTrue(), timeout: timeout)
                 }
-                
+
                 it("provides an error") {
                     expect(sessionDelegate.failedRequestError).toEventuallyNot(beNil(), timeout: timeout)
                     guard let error = sessionDelegate.failedRequestError else {
                         fail("Should have gotten an error")
                         return
                     }
-                    
+
                     expect(error).to(matchError(TurboError.http(statusCode: 404)))
                 }
-                
+
                 it("calls sessionDidFinishRequest delegate method") {
                     expect(sessionDelegate.sessionDidFinishRequestCalled).toEventually(beTrue(), timeout: timeout)
                 }
             }
-            
+
             context("when visit fails from missing library") {
                 beforeEach {
                     let visitable = TestVisitable(url: self.url("/missing-library"))
                     session.visit(visitable)
                 }
-                
+
                 it("calls sessionDidFailRequest delegate method") {
                     expect(sessionDelegate.sessionDidFailRequestCalled).toEventually(beTrue(), timeout: timeout)
                 }
-                
+
                 it("provides an page load error") {
                     expect(sessionDelegate.failedRequestError).toEventuallyNot(beNil(), timeout: timeout)
                     guard let error = sessionDelegate.failedRequestError else {
                         fail("Should have gotten an error")
                         return
                     }
-                    
+
                     expect(error).to(matchError(TurboError.pageLoadFailure))
                 }
-                
+
                 it("calls sessionDidFinishRequest delegate method") {
                     expect(sessionDelegate.sessionDidFinishRequestCalled).toEventually(beTrue(), timeout: timeout)
                 }
             }
-            
+
             describe("Turbolinks 5 compatibility") {
                 it("loads the page and sets the adapter") {
                     let visitable = TestVisitable(url: self.url("/turbolinks"))
                     session.visit(visitable)
-                    
+
                     expect(sessionDelegate.sessionDidLoadWebViewCalled).toEventually(beTrue(), timeout: timeout)
-                    
+
                     waitUntil { done in
-                        session.webView.evaluateJavaScript("Turbolinks.controller.adapter === window.turboNative") { result, error in
+                        session.webView.evaluateJavaScript("Turbolinks.controller.adapter === window.turboNative") { result, _ in
                             XCTAssertEqual(result as? Bool, true)
                             done()
                         }
                     }
                 }
             }
-            
+
             describe("Turbolinks 5.3 compatibility") {
                 it("loads the page and sets the adapter") {
                     let visitable = TestVisitable(url: self.url("/turbolinks-5.3"))
                     session.visit(visitable)
-                    
+
                     expect(sessionDelegate.sessionDidLoadWebViewCalled).toEventually(beTrue(), timeout: timeout)
-                    
+
                     waitUntil { done in
-                        session.webView.evaluateJavaScript("Turbolinks.controller.adapter === window.turboNative") { result, error in
+                        session.webView.evaluateJavaScript("Turbolinks.controller.adapter === window.turboNative") { result, _ in
                             XCTAssertEqual(result as? Bool, true)
                             done()
                         }
@@ -168,39 +168,39 @@ class SessionSpec: QuickSpec {
             }
         }
     }
-    
+
     // MARK: - Server
-    
+
     private func url(_ path: String) -> URL {
         let relativePath = path.hasPrefix("/") ? String(path.dropFirst()) : path
         return server.serverURL!.appendingPathComponent(relativePath)
     }
-    
+
     private func startServer() {
         let bundle = Bundle(for: SessionSpec.self)
         let resources = bundle.resourcePath!
-        
+
         server.addGETHandler(forBasePath: "/", directoryPath: resources, indexFilename: "turbo.html", cacheAge: 0, allowRangeRequests: true)
 
         server.addHandler(forMethod: "GET", path: "/turbolinks", request: GCDWebServerRequest.self) { _ in
             GCDWebServerDataResponse(data: try! Data(contentsOf: bundle.url(forResource: "turbolinks", withExtension: "html")!), contentType: "text/html")
         }
-        
+
         server.addHandler(forMethod: "GET", path: "/turbolinks-5.3", request: GCDWebServerRequest.self) { _ in
             GCDWebServerDataResponse(data: try! Data(contentsOf: bundle.url(forResource: "turbolinks-5.3", withExtension: "html")!), contentType: "text/html")
         }
-        
+
         server.addHandler(forMethod: "GET", path: "/missing-library", request: GCDWebServerRequest.self) { _ in
             GCDWebServerDataResponse(html: "<html></html>")
         }
-        
+
         server.addHandler(forMethod: "GET", path: "/invalid", request: GCDWebServerRequest.self) { _ in
             GCDWebServerResponse(statusCode: 404)
         }
-        
+
         server.start(withPort: 8080, bonjourName: nil)
     }
-    
+
     private func stopServer() {
         server.stop()
     }

--- a/Tests/Test.swift
+++ b/Tests/Test.swift
@@ -1,25 +1,28 @@
-import UIKit
 @testable import Turbo
+import UIKit
 
 class TestVisitable: UIViewController, Visitable {
     // MARK: - Tests
+
     var visitableDidRenderCalled = false
-    
+
     // MARK: - Visitable
+
     var visitableDelegate: VisitableDelegate?
     var visitableView: VisitableView!
     var visitableURL: URL!
-    
+
     init(url: URL) {
         self.visitableURL = url
         self.visitableView = VisitableView(frame: .zero)
         super.init(nibName: nil, bundle: nil)
     }
-    
+
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     func visitableDidRender() {
         visitableDidRenderCalled = true
     }
@@ -29,36 +32,33 @@ class TestSessionDelegate: NSObject, SessionDelegate {
     var sessionDidLoadWebViewCalled = false
     var sessionDidStartRequestCalled = false
     var sessionDidFinishRequestCalled = false
-    var failedRequestError: Error? = nil
+    var failedRequestError: Error?
     var sessionDidFailRequestCalled = false
     var sessionDidProposeVisitCalled = false
-    
+
     func sessionDidLoadWebView(_ session: Session) {
         sessionDidLoadWebViewCalled = true
     }
-    
+
     func sessionDidStartRequest(_ session: Session) {
         sessionDidStartRequestCalled = true
     }
-    
+
     func sessionDidFinishRequest(_ session: Session) {
         sessionDidFinishRequestCalled = true
     }
-    
-    func sesssionDidStartFormSubmission(_ session: Session) {
-    }
-    
-    func sessionDidFinishFormSubmission(_ session: Session) {
-    }
-    
-    func sessionWebViewProcessDidTerminate(_ session: Session) {
-    }
-    
+
+    func sesssionDidStartFormSubmission(_ session: Session) {}
+
+    func sessionDidFinishFormSubmission(_ session: Session) {}
+
+    func sessionWebViewProcessDidTerminate(_ session: Session) {}
+
     func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error) {
         sessionDidFailRequestCalled = true
         failedRequestError = error
     }
-    
+
     func session(_ session: Session, didProposeVisit proposal: VisitProposal) {
         sessionDidProposeVisitCalled = true
     }

--- a/Tests/VisitOptionsSpec.swift
+++ b/Tests/VisitOptionsSpec.swift
@@ -1,5 +1,5 @@
-import Quick
 import Nimble
+import Quick
 @testable import Turbo
 
 class VisitOptionsSpec: QuickSpec {
@@ -7,7 +7,7 @@ class VisitOptionsSpec: QuickSpec {
         describe("Decodable") {
             it("defaults to advance action when not provided") {
                 let json = "{}".data(using: .utf8)!
-                
+
                 do {
                     let decoder = JSONDecoder()
                     let options = try decoder.decode(VisitOptions.self, from: json)
@@ -17,12 +17,12 @@ class VisitOptionsSpec: QuickSpec {
                     fail(error.localizedDescription)
                 }
             }
-            
+
             it("uses provided action when not nil") {
                 let json = """
                     {"action": "restore"}
                 """.data(using: .utf8)!
-                
+
                 do {
                     let decoder = JSONDecoder()
                     let options = try decoder.decode(VisitOptions.self, from: json)
@@ -32,12 +32,12 @@ class VisitOptionsSpec: QuickSpec {
                     fail(error.localizedDescription)
                 }
             }
-            
+
             it("can be initialized with response") {
                 let json = """
                     {"response": {"statusCode": 200, "responseHTML": "<html></html>"}}
                 """.data(using: .utf8)!
-                
+
                 do {
                     let decoder = JSONDecoder()
                     let options = try decoder.decode(VisitOptions.self, from: json)
@@ -45,7 +45,7 @@ class VisitOptionsSpec: QuickSpec {
                     expect(options.response).toNot(beNil())
                     expect(options.response!.statusCode) == 200
                     expect(options.response!.responseHTML) == "<html></html>"
-                    
+
                 } catch {
                     fail(error.localizedDescription)
                 }


### PR DESCRIPTION
This PR lints and formats every Swift file according to the standards from [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).

* Remove trailing whitespace
* Consolidate double blank lines
* Alphabetize imports
* Use enums over structs when only accessed statically
* Consolidate spacing and indentation
* Use commas over ampersands in if statements
* One line methods with empty implementations

I understand that I made some personal decisions with the formatting options provided. But I don't think anyone will have a problem applying others (like trailing whitespace).

Think of this PR as the beginning of a discussion: do we have a style guide for this project? And if not, are we interested in implementing and enforcing one? My vote is yes, and I'm happy to take the lead if this is the direction the maintainers would like to go.