### PR TITLE
Config to delay activity indicator animation

### DIFF
--- a/Docs/Configuration.md
+++ b/Docs/Configuration.md
@@ -1,0 +1,21 @@
+# Configuration
+
+A few options can be configured on the library.
+
+## Logging
+
+Enable debug logging, including every interaction with the Turbo Session, Bridge, and visits.
+
+```swift
+#if DEBUG
+TurboLog.debugLoggingEnabled = true
+#endif
+```
+
+## Activity indicator animation delay
+
+Delay the initial animation and display of the activity indicator (spinner) when loading requests, in seconds.
+
+```swift
+Turbo.activityIndicatorViewDelay = 0.5
+```

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The best way to get started with Turbo iOS to try out the demo app first to get 
 - [Overview](Docs/Overview.md)
 - [Authentication](Docs/Authentication.md)
 - [Path Configuration](Docs/PathConfiguration.md)
+- [Turbo Configuration](Docs/Configuration.md)
 - [Migration](Docs/Migration.md)
 - [Advanced](Docs/Advanced.md)
 

--- a/Source/Turbo.swift
+++ b/Source/Turbo.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public enum Turbo {
+    public static var activityIndicatorViewDelay: TimeInterval = 0
+}

--- a/Source/Visitable/VisitableView.swift
+++ b/Source/Visitable/VisitableView.swift
@@ -82,6 +82,8 @@ open class VisitableView: UIView {
 
     // MARK: Activity Indicator
 
+    private var activityIndicatorViewStoppedAnimating = false
+
     open lazy var activityIndicatorView: UIActivityIndicatorView = {
         let view: UIActivityIndicatorView
         
@@ -108,12 +110,19 @@ open class VisitableView: UIView {
     open func showActivityIndicator() {
         guard !isRefreshing else { return }
 
-        activityIndicatorView.startAnimating()
-        bringSubviewToFront(activityIndicatorView)
+        perform(#selector(startAnimatingActivityIndicatorView), with: nil, afterDelay: Turbo.activityIndicatorViewDelay)
     }
 
     open func hideActivityIndicator() {
+        activityIndicatorViewStoppedAnimating = true
         activityIndicatorView.stopAnimating()
+    }
+
+    @objc private func startAnimatingActivityIndicatorView() {
+        guard !activityIndicatorViewStoppedAnimating else { return }
+
+        activityIndicatorView.startAnimating()
+        bringSubviewToFront(activityIndicatorView)
     }
 
     // MARK: Screenshots

--- a/Turbo.xcodeproj/project.pbxproj
+++ b/Turbo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		844BAE4B2897309A00124498 /* Turbo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844BAE4A2897309A00124498 /* Turbo.swift */; };
 		C10DF22A257ABD3D009412E7 /* VisitProposal.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10DF229257ABD3D009412E7 /* VisitProposal.swift */; };
 		C13ABAF1259142200001E6F4 /* turbolinks-5.3.html in Resources */ = {isa = PBXBuildFile; fileRef = C13ABAF0259142200001E6F4 /* turbolinks-5.3.html */; };
 		C13ABAF72591422F0001E6F4 /* turbo.html in Resources */ = {isa = PBXBuildFile; fileRef = C13ABAF62591422F0001E6F4 /* turbo.html */; };
@@ -67,6 +68,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		844BAE4A2897309A00124498 /* Turbo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Turbo.swift; sourceTree = "<group>"; };
 		C10DF229257ABD3D009412E7 /* VisitProposal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitProposal.swift; sourceTree = "<group>"; };
 		C13ABAF0259142200001E6F4 /* turbolinks-5.3.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "turbolinks-5.3.html"; sourceTree = "<group>"; };
 		C13ABAF62591422F0001E6F4 /* turbo.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = turbo.html; sourceTree = "<group>"; };
@@ -169,8 +171,9 @@
 				C149E3C72575891C00158E8C /* Visitable */,
 				C149E3B62575863D00158E8C /* WebView */,
 				C149E3B52575862800158E8C /* Path Configuration */,
-				C149E3892575847700158E8C /* TurboError.swift */,
 				C149E37A2575847700158E8C /* Logging.swift */,
+				844BAE4A2897309A00124498 /* Turbo.swift */,
+				C149E3892575847700158E8C /* TurboError.swift */,
 				C149E3522575780900158E8C /* Info.plist */,
 			);
 			name = Turbo;
@@ -413,6 +416,7 @@
 				C149E38E2575847700158E8C /* SessionDelegate.swift in Sources */,
 				C149E39A2575847800158E8C /* VisitableViewController.swift in Sources */,
 				C149E3C9257589C700158E8C /* VisitResponse.swift in Sources */,
+				844BAE4B2897309A00124498 /* Turbo.swift in Sources */,
 				C149E39B2575847800158E8C /* ScriptMessage.swift in Sources */,
 				C149E3972575847800158E8C /* ScriptMessageHandler.swift in Sources */,
 				C149E3962575847800158E8C /* Visit.swift in Sources */,


### PR DESCRIPTION
This PR adds a configuration option to delay the activity indicator animation. It was inspired by #89.

I also added a new documentation file, `Configuration.md`. This outlines how to configure this change along with the existing logging option.

The default delay is set to `0` so this should be safe to maintain backwards compatibility.