### PR TITLE
Add support `theme-color` for the website

### DIFF
--- a/Demo/ViewController.swift
+++ b/Demo/ViewController.swift
@@ -9,7 +9,7 @@ final class ViewController: VisitableViewController, ErrorPresenter {
             navigationItem.backButtonDisplayMode = .minimal
         }
         
-        view.backgroundColor = .systemBackground
+        view.backgroundColor = visitableView.webView?.themeColor ?? .systemBackground
         
         if presentingViewController != nil {
             navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(dismissModal))


### PR DESCRIPTION
The proposed change adds support for a custom color (light/dark) from the HTML attribute, which can be helpful.

```html
<!doctype html>
<html> 

<head>
  <meta name="theme-color" content="#f5f7fa" media="(prefers-color-scheme: light)">
  <meta name="theme-color" content="#232730" media="(prefers-color-scheme: dark)">
</head>

...
```

This can be a convenient and intuitive way to style an element, especially for users unfamiliar with Swift. Also, this ensures that the colors will always be up-to-date and the same as in the PWA version.

In the end, this will increase the usability for those who start cloning a `Demo` project.
