### PR TITLE
Fix warning but not with the Xcode fixit

### DIFF
--- a/Demo/ErrorPresenter.swift
+++ b/Demo/ErrorPresenter.swift
@@ -101,7 +101,7 @@ final class ErrorViewController: UIViewController {
         return label
     }()
     
-    private let button: UIButton = {
+    private lazy var button: UIButton = {
         let button = UIButton(type: .system)
         button.setTitle("Retry", for: .normal)
         button.addTarget(self, action: #selector(performAction(_:)), for: .touchUpInside)


### PR DESCRIPTION
Switching `let` to `lazy var` means that the `self` context is the instance, not the class. Which is what we want. The Xcode fixit is incorrect and would cause the app to crash.