### PR TITLE
Update Package.swift to match minimum features

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "Turbo",
     platforms: [
-        .iOS(.v12)
+        .iOS(.v13)
     ],
     products: [
         .library(


### PR DESCRIPTION
`UIActivityIndicatorView(style: .medium)` — This requires iOS 13+, so a build error happens due to the Package saying it's targeted at v12. This addresses that.