### PR TITLE
Fix for "No Inspectable Applications" from Safari

### DIFF
--- a/Demo/SceneController.swift
+++ b/Demo/SceneController.swift
@@ -49,13 +49,14 @@ final class SceneController: UIResponder {
         let configuration = WKWebViewConfiguration()
         configuration.applicationNameForUserAgent = "Turbo Native iOS"
         configuration.processPool = Self.sharedProcessPool
-        
-        let session = Session(webViewConfiguration: configuration)
+
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        if #available(iOS 16.4, *) {
+            webView.isInspectable = true
+        }
+        let session = Session(webView: webView)
         session.delegate = self
         session.pathConfiguration = pathConfiguration
-        if #available(iOS 16.4, *) {
-            session.webView.isInspectable = true
-        }
         return session
     }
     

--- a/Demo/SceneController.swift
+++ b/Demo/SceneController.swift
@@ -53,6 +53,9 @@ final class SceneController: UIResponder {
         let session = Session(webViewConfiguration: configuration)
         session.delegate = self
         session.pathConfiguration = pathConfiguration
+        if #available(iOS 16.4, *) {
+            session.webView.isInspectable = true
+        }
         return session
     }
     


### PR DESCRIPTION
In trying the Demo, I was getting “No Inspectable Applications” in Safari when trying to attach to the simulator’s web view.

I realised this is “as designed” from iOS 16.4 https://webkit.org/blog/13936/enabling-the-inspection-of-web-content-in-apps/ and I was able to resolve by adding the following in the SceneController

```swift
if #available(iOS 16.4, *) {
    session.webView.isInspectable = true
}
```