### PR TITLE
Decouple `Visitable` from `VisitableView`

### DIFF
--- a/Source/Visitable/Visitable.swift
+++ b/Source/Visitable/Visitable.swift
@@ -8,7 +8,7 @@ public protocol VisitableDelegate: AnyObject {
     func visitableDidRequestRefresh(_ visitable: Visitable)
 }
 
-public protocol Visitable: AnyObject {
+public protocol Visitable: AnyObject, VisitableViewDelegate {
     var visitableViewController: UIViewController { get }
     var visitableDelegate: VisitableDelegate? { get set } 
     var visitableView: VisitableView! { get }
@@ -17,6 +17,13 @@ public protocol Visitable: AnyObject {
     func visitableDidRender()
     func showVisitableActivityIndicator()
     func hideVisitableActivityIndicator()
+}
+
+// MARK: VisitableViewDelegate
+extension Visitable {
+    public func didPullToRefresh(control: UIRefreshControl) {
+        visitableDelegate?.visitableDidRequestRefresh(self)
+    }
 }
 
 extension Visitable {
@@ -33,7 +40,7 @@ extension Visitable {
     }
 
     func activateVisitableWebView(_ webView: WKWebView) {
-        visitableView.activateWebView(webView, forVisitable: self)
+        visitableView.activateWebView(webView, delegate: self)
     }
 
     func deactivateVisitableWebView() {

--- a/Source/Visitable/VisitableView.swift
+++ b/Source/Visitable/VisitableView.swift
@@ -1,6 +1,10 @@
 import UIKit
 import WebKit
 
+public protocol VisitableViewDelegate : AnyObject {
+    func didPullToRefresh(control: UIRefreshControl)
+}
+
 /// `VisitableView`'s purpose is to manage implementation details regarding visibility for:
 /// - a webView running Turbo
 /// - a screenshot container view
@@ -24,11 +28,12 @@ open class VisitableView: UIView {
     // MARK: Web View
 
     open weak var webView: WKWebView?
-    private weak var visitable: Visitable?
+    
+    private weak var delegate: VisitableViewDelegate?
 
-    open func activateWebView(_ webView: WKWebView, forVisitable visitable: Visitable) {
+    open func activateWebView(_ webView: WKWebView, delegate: VisitableViewDelegate) {
         self.webView = webView
-        self.visitable = visitable
+        self.delegate = delegate
         addSubview(webView)
         addFillConstraints(for: webView)
         installRefreshControl()
@@ -39,7 +44,6 @@ open class VisitableView: UIView {
         removeRefreshControl()
         webView?.removeFromSuperview()
         webView = nil
-        visitable = nil
     }
 
     private func showOrHideWebView() {
@@ -82,7 +86,7 @@ open class VisitableView: UIView {
     }
 
     @objc func refresh(_ sender: AnyObject) {
-        visitable?.visitableViewDidRequestRefresh()
+        delegate?.didPullToRefresh(control: refreshControl)
     }
 
     // MARK: Activity Indicator

--- a/Source/Visitable/VisitableView.swift
+++ b/Source/Visitable/VisitableView.swift
@@ -44,6 +44,7 @@ open class VisitableView: UIView {
         removeRefreshControl()
         webView?.removeFromSuperview()
         webView = nil
+        delegate = nil
     }
 
     private func showOrHideWebView() {

--- a/Source/Visitable/VisitableView.swift
+++ b/Source/Visitable/VisitableView.swift
@@ -1,7 +1,12 @@
 import UIKit
 import WebKit
 
+/// `VisitableView`'s purpose is to manage implementation details regarding visibility for:
+/// - a webView running Turbo
+/// - a screenshot container view
+/// - an activity indicator view
 open class VisitableView: UIView {
+    
     public override init(frame: CGRect) {
         super.init(frame: frame)
         setup()

--- a/Source/Visitable/VisitableView.swift
+++ b/Source/Visitable/VisitableView.swift
@@ -18,7 +18,7 @@ open class VisitableView: UIView {
 
     // MARK: Web View
 
-    open var webView: WKWebView?
+    open weak var webView: WKWebView?
     private weak var visitable: Visitable?
 
     open func activateWebView(_ webView: WKWebView, forVisitable visitable: Visitable) {


### PR DESCRIPTION
Decoupling `VisitableView` from its direct reference to a `Visitable` is an easy quick win.