### PR TITLE
Fix refresh control positioning

### DIFF
--- a/Source/Visitable/VisitableView.swift
+++ b/Source/Visitable/VisitableView.swift
@@ -67,13 +67,13 @@ open class VisitableView: UIView {
         guard let scrollView = webView?.scrollView, allowsPullToRefresh else { return }
         
         #if !targetEnvironment(macCatalyst)
-        scrollView.addSubview(refreshControl)
+        scrollView.refreshControl = refreshControl
         #endif
     }
 
     private func removeRefreshControl() {
         refreshControl.endRefreshing()
-        refreshControl.removeFromSuperview()
+        webView?.scrollView.refreshControl = nil
     }
 
     @objc func refresh(_ sender: AnyObject) {

--- a/Source/Visitable/VisitableView.swift
+++ b/Source/Visitable/VisitableView.swift
@@ -45,6 +45,7 @@ open class VisitableView: UIView {
 
     open lazy var refreshControl: UIRefreshControl = {
         let refreshControl = UIRefreshControl()
+        refreshControl.translatesAutoresizingMaskIntoConstraints = false
         refreshControl.addTarget(self, action: #selector(refresh(_:)), for: .valueChanged)
         return refreshControl
     }()
@@ -67,13 +68,21 @@ open class VisitableView: UIView {
         guard let scrollView = webView?.scrollView, allowsPullToRefresh else { return }
         
         #if !targetEnvironment(macCatalyst)
-        scrollView.refreshControl = refreshControl
+        scrollView.addSubview(refreshControl)
+
+        let height = refreshControl.frame.height > 0 ? refreshControl.frame.height : 60
+        
+        NSLayoutConstraint.activate([
+            refreshControl.centerXAnchor.constraint(equalTo: centerXAnchor),
+            refreshControl.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+            refreshControl.heightAnchor.constraint(equalToConstant: height)
+        ])
         #endif
     }
 
     private func removeRefreshControl() {
         refreshControl.endRefreshing()
-        webView?.scrollView.refreshControl = nil
+        refreshControl.removeFromSuperview()
     }
 
     @objc func refresh(_ sender: AnyObject) {

--- a/Source/Visitable/VisitableView.swift
+++ b/Source/Visitable/VisitableView.swift
@@ -70,12 +70,14 @@ open class VisitableView: UIView {
         #if !targetEnvironment(macCatalyst)
         scrollView.addSubview(refreshControl)
 
-        let height = refreshControl.frame.height > 0 ? refreshControl.frame.height : 60
+        /// Infer refresh control's default height from its frame, if given.
+        /// Otherwise fallback to 60 (the default height).
+        let refreshControlHeight = refreshControl.frame.height > 0 ? refreshControl.frame.height : 60
         
         NSLayoutConstraint.activate([
             refreshControl.centerXAnchor.constraint(equalTo: centerXAnchor),
             refreshControl.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
-            refreshControl.heightAnchor.constraint(equalToConstant: height)
+            refreshControl.heightAnchor.constraint(equalToConstant: refreshControlHeight)
         ])
         #endif
     }


### PR DESCRIPTION
### Summary

This PR fixes refresh control's positioning by using constraints.

**Context**

`UIRefreshControl` is a critical component that enables users to refresh content by pulling down on a scroll view.
The conventional approach involves assigning the `UIRefreshControl` directly to the web view's scroll view. However, in a specific case (using `viewport-fit=cover`), this approach did not provide the desired functionality. See https://github.com/hotwired/turbo-ios/pull/73.

**Solution**

To address this issue, we have updated the `UIRefreshControl` positioning by utilizing constraints. With this approach, we can ensure the `UIRefreshControl` adjusts properly within the safe area.
