### PR TITLE
Allow passing URLRequest as PathConfiguration source

### DIFF
--- a/Source/Path Configuration/PathConfiguration.swift
+++ b/Source/Path Configuration/PathConfiguration.swift
@@ -92,5 +92,6 @@ extension PathConfiguration {
         case data(Data)
         case file(URL)
         case server(URL)
+        case serverRequest(URLRequest)
     }
 }

--- a/Source/Path Configuration/PathConfigurationLoader.swift
+++ b/Source/Path Configuration/PathConfigurationLoader.swift
@@ -23,6 +23,8 @@ final class PathConfigurationLoader {
                 loadFile(url)
             case .server(let url):
                 download(from: url)
+            case .serverRequest(let request):
+                download(with: request)
             }
         }
     }
@@ -32,12 +34,17 @@ final class PathConfigurationLoader {
     private func download(from url: URL) {
         precondition(!url.isFileURL, "URL provided for server is a file url")
         
+        download(with: URLRequest(url: url))
+    }
+    
+    private func download(with request: URLRequest) {
+        
         // Immediately load most recent cached version if available
         if let data = cachedData() {
             loadData(data)
         }
         
-        URLSession.shared.dataTask(with: url) { [weak self] data, response, error in
+        URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
             guard let data = data,
                 let httpResponse = response as? HTTPURLResponse,
                 httpResponse.statusCode == 200


### PR DESCRIPTION
This non-breaking change introduces another case to the `PathConfiguration.Source` enum, a `.serverRequest(URLRequest)` so that clients can customize how the configuration file is loaded from the network. 

This was prompted by our use in HEY – we'd like to be able to set a different cache policy on the request so that locally cached files are ignored and we always retrieve the latest possible file from the server. But I can see this being a reasonable use case for other clients too, while default behaviour is still provided by the `.server(URL)` source type.