### PR TITLE
Increase turbo:load event timeout to 30 seconds

### DIFF
--- a/Source/WebView/turbo.js
+++ b/Source/WebView/turbo.js
@@ -1,5 +1,5 @@
 (() => {
-  const TURBO_LOAD_TIMEOUT = 10000
+  const TURBO_LOAD_TIMEOUT = 30000
 
   // Bridge between Turbo JS and native code. Built for Turbo 7
   // with backwards compatibility for Turbolinks 5

--- a/Source/WebView/turbo.js
+++ b/Source/WebView/turbo.js
@@ -1,5 +1,5 @@
 (() => {
-  const TURBO_LOAD_TIMEOUT = 4000
+  const TURBO_LOAD_TIMEOUT = 10000
 
   // Bridge between Turbo JS and native code. Built for Turbo 7
   // with backwards compatibility for Turbolinks 5


### PR DESCRIPTION
Internally, we've noted that the timeout is too short in some cases, e.g. slower connections, which may cause `pageLoadFailed()` to be triggered prematurely. Specifically, loading many import map javascript resources through `es-module-shims` can trigger the `turbo:load` event to trigger well after `document.readyState == "complete"`.

For now, we suspect that increasing this time out will alleviate some of those scenarios. This is an follow-up to changes made in: https://github.com/hotwired/turbo-ios/pull/52