### PR TITLE
Expose web view activation/deactivation in Visitable

### DIFF
--- a/Source/Visitable/Visitable.swift
+++ b/Source/Visitable/Visitable.swift
@@ -17,6 +17,8 @@ public protocol Visitable: AnyObject {
     func visitableDidRender()
     func showVisitableActivityIndicator()
     func hideVisitableActivityIndicator()
+    func activateVisitableWebView(_ webView: WKWebView)
+    func deactivateVisitableWebView()
 }
 
 extension Visitable {
@@ -32,11 +34,11 @@ extension Visitable {
         visitableView.hideActivityIndicator()
     }
 
-    func activateVisitableWebView(_ webView: WKWebView) {
+    public func activateVisitableWebView(_ webView: WKWebView) {
         visitableView.activateWebView(webView, forVisitable: self)
     }
 
-    func deactivateVisitableWebView() {
+    public func deactivateVisitableWebView() {
         visitableView.deactivateWebView()
     }
 

--- a/Source/Visitable/Visitable.swift
+++ b/Source/Visitable/Visitable.swift
@@ -6,6 +6,8 @@ public protocol VisitableDelegate: AnyObject {
     func visitableViewDidAppear(_ visitable: Visitable)
     func visitableDidRequestReload(_ visitable: Visitable)
     func visitableDidRequestRefresh(_ visitable: Visitable)
+    func visitableDidActivateWebView(_ webView: WKWebView)
+    func visitableDidDeactivateWebView(_ visitable: Visitable)
 }
 
 public protocol Visitable: AnyObject {
@@ -17,8 +19,6 @@ public protocol Visitable: AnyObject {
     func visitableDidRender()
     func showVisitableActivityIndicator()
     func hideVisitableActivityIndicator()
-    func activateVisitableWebView(_ webView: WKWebView)
-    func deactivateVisitableWebView()
 }
 
 extension Visitable {
@@ -34,12 +34,14 @@ extension Visitable {
         visitableView.hideActivityIndicator()
     }
 
-    public func activateVisitableWebView(_ webView: WKWebView) {
+    func activateVisitableWebView(_ webView: WKWebView) {
         visitableView.activateWebView(webView, forVisitable: self)
+        visitableDelegate?.visitableDidActivateWebView(webView)
     }
 
-    public func deactivateVisitableWebView() {
+    func deactivateVisitableWebView() {
         visitableView.deactivateWebView()
+        visitableDelegate?.visitableDidDeactivateWebView(self)
     }
 
     func updateVisitableScreenshot() {

--- a/Source/Visitable/Visitable.swift
+++ b/Source/Visitable/Visitable.swift
@@ -34,6 +34,14 @@ extension Visitable {
     public func hideVisitableActivityIndicator() {
         visitableView.hideActivityIndicator()
     }
+    
+    public func visitableDidActivateWebView(_ webView: WKWebView) {
+        // No-op
+    }
+    
+    public func visitableDidDeactivateWebView() {
+        // No-op
+    }
 
     func activateVisitableWebView(_ webView: WKWebView) {
         visitableView.activateWebView(webView, forVisitable: self)

--- a/Source/Visitable/Visitable.swift
+++ b/Source/Visitable/Visitable.swift
@@ -6,8 +6,6 @@ public protocol VisitableDelegate: AnyObject {
     func visitableViewDidAppear(_ visitable: Visitable)
     func visitableDidRequestReload(_ visitable: Visitable)
     func visitableDidRequestRefresh(_ visitable: Visitable)
-    func visitableDidActivateWebView(_ webView: WKWebView)
-    func visitableDidDeactivateWebView(_ visitable: Visitable)
 }
 
 public protocol Visitable: AnyObject {
@@ -19,6 +17,9 @@ public protocol Visitable: AnyObject {
     func visitableDidRender()
     func showVisitableActivityIndicator()
     func hideVisitableActivityIndicator()
+    
+    func visitableDidActivateWebView(_ webView: WKWebView)
+    func visitableDidDeactivateWebView()
 }
 
 extension Visitable {
@@ -36,12 +37,12 @@ extension Visitable {
 
     func activateVisitableWebView(_ webView: WKWebView) {
         visitableView.activateWebView(webView, forVisitable: self)
-        visitableDelegate?.visitableDidActivateWebView(webView)
+        visitableDidActivateWebView(webView)
     }
 
     func deactivateVisitableWebView() {
         visitableView.deactivateWebView()
-        visitableDelegate?.visitableDidDeactivateWebView(self)
+        visitableDidDeactivateWebView()
     }
 
     func updateVisitableScreenshot() {

--- a/Source/Visitable/VisitableViewController.swift
+++ b/Source/Visitable/VisitableViewController.swift
@@ -42,14 +42,6 @@ open class VisitableViewController: UIViewController, Visitable {
         visitableView.hideActivityIndicator()
     }
     
-    open func visitableDidActivateWebView(_ webView: WKWebView) {
-        // No-op
-    }
-    
-    open func visitableDidDeactivateWebView() {
-        // No-op
-    }
-    
     // MARK: Visitable View
 
     open private(set) lazy var visitableView: VisitableView! = {

--- a/Source/Visitable/VisitableViewController.swift
+++ b/Source/Visitable/VisitableViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import WebKit
 
 open class VisitableViewController: UIViewController, Visitable {
     open weak var visitableDelegate: VisitableDelegate?

--- a/Source/Visitable/VisitableViewController.swift
+++ b/Source/Visitable/VisitableViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WebKit
 
 open class VisitableViewController: UIViewController, Visitable {
     open weak var visitableDelegate: VisitableDelegate?
@@ -39,6 +40,14 @@ open class VisitableViewController: UIViewController, Visitable {
     
     open func hideVisitableActivityIndicator() {
         visitableView.hideActivityIndicator()
+    }
+    
+    open func visitableDidActivateWebView(_ webView: WKWebView) {
+        // No-op
+    }
+    
+    open func visitableDidDeactivateWebView() {
+        // No-op
     }
     
     // MARK: Visitable View

--- a/Tests/SessionSpec.swift
+++ b/Tests/SessionSpec.swift
@@ -5,7 +5,7 @@ import Nimble
 import GCDWebServers
 @testable import Turbo
 
-private let timeout = DispatchTimeInterval.seconds(15)
+private let timeout = DispatchTimeInterval.seconds(35)
 
 class SessionSpec: QuickSpec {
     let server = GCDWebServer()

--- a/Tests/Test.swift
+++ b/Tests/Test.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WebKit
 @testable import Turbo
 
 class TestVisitable: UIViewController, Visitable {

--- a/Tests/Test.swift
+++ b/Tests/Test.swift
@@ -4,6 +4,8 @@ import UIKit
 class TestVisitable: UIViewController, Visitable {
     // MARK: - Tests
     var visitableDidRenderCalled = false
+    var visitableDidActivateWebViewWasCalled = false
+    var visitableDidDeactivateWebViewWasCalled = false
     
     // MARK: - Visitable
     var visitableDelegate: VisitableDelegate?
@@ -22,6 +24,14 @@ class TestVisitable: UIViewController, Visitable {
     
     func visitableDidRender() {
         visitableDidRenderCalled = true
+    }
+    
+    func visitableDidActivateWebView(_ webView: WKWebView) {
+        visitableDidActivateWebViewWasCalled = true
+    }
+    
+    func visitableDidDeactivateWebView() {
+        visitableDidDeactivateWebViewWasCalled = true
     }
 }
 


### PR DESCRIPTION
This PR exposes web view activation/deactivation in `Visitable`.

The main reason we are exposing them is because we need to delegate the web view activation/deactivation to `Strada`.