### PR TITLE
Let `Session` know it needs to reload

### DIFF
--- a/Source/Session/Session.swift
+++ b/Source/Session/Session.swift
@@ -14,6 +14,7 @@ public class Session: NSObject {
     private lazy var bridge = WebViewBridge(webView: webView)
     private var initialized = false
     private var refreshing = false
+    private var needsReload = false
 
     /// Automatically creates a web view with the passed-in configuration
     public convenience init(webViewConfiguration: WKWebViewConfiguration? = nil) {
@@ -89,6 +90,10 @@ public class Session: NSObject {
     
     public func clearSnapshotCache() {
         bridge.clearSnapshotCache()
+    }
+
+    public func setNeedsReload() {
+        needsReload = true
     }
 
     // MARK: Visitable activation
@@ -224,6 +229,9 @@ extension Session: VisitableDelegate {
         } else if visitable !== topmostVisit.visitable {
             // Navigating backward
             visit(visitable, action: .restore)
+        } else if needsReload {
+            reload()
+            needsReload = false
         }
     }
 


### PR DESCRIPTION
When working with multiple Turbo instances across tabs data can easily become out of sync. Submitting a form on the first tab might change data currently displayed on the second. And signing in on one tab might change _everything_ about the others!

`Session.clearSnapshotCache()` only works when navigating _back_ to a cached page. It doesn't help if the active screen is being shown on a tab.

This PR introduced a new public function, `Session.setNeedsReload()`. When the session's underlying `Visitable` appears it reloads if this function was called earlier.

---

The name of the function feels a bit _off_. `clearSnapshotCache()` is perfect, it is action-oriented and easy to understand. Is there a similar name for `setNeedsReload()`?

Alternatively, we ignore Turbo.js's snapshot cache cleaning and always reload the page (when it appears). I don't think that would change much, if any, existing behavior.