### PR TITLE
Add a non-visitable function to the adapter interface

### DIFF
--- a/Source/WebView/turbo.js
+++ b/Source/WebView/turbo.js
@@ -109,7 +109,7 @@
       this.postMessage("visitProposed", { location: location.toString(), options: options })
     }
 
-    visitProposedToNonVisitableLocation(location) {
+    adapterVisitProposedToNonVisitableLocation(location) {
       this.postMessage("visitProposed", { location: location.toString(), options: { } })
     }
 

--- a/Source/WebView/turbo.js
+++ b/Source/WebView/turbo.js
@@ -109,6 +109,10 @@
       this.postMessage("visitProposed", { location: location.toString(), options: options })
     }
 
+    visitProposedToNonVisitableLocation(location) {
+      this.postMessage("visitProposed", { location: location.toString(), options: { } })
+    }
+
     // Turbolinks 5
     visitProposedToLocationWithAction(location, action) {
       this.visitProposedToLocation(location, { action })


### PR DESCRIPTION
This allows us to pass changes to the native adapter even for non-visitable links.