### PR TITLE
Fix wrong comparission in PathConfiguration

### DIFF
--- a/Source/Path Configuration/PathConfiguration.swift
+++ b/Source/Path Configuration/PathConfiguration.swift
@@ -96,7 +96,7 @@ public final class PathConfiguration {
 
 extension PathConfiguration: Equatable {
     public static func == (lhs: PathConfiguration, rhs: PathConfiguration) -> Bool {
-        lhs.settings == lhs.settings && lhs.rules == rhs.rules
+        lhs.settings == rhs.settings && lhs.rules == rhs.rules
     }
 }
 


### PR DESCRIPTION
I was browsing through the code to understand it better where I found this expression:
```
lhs.settings == lhs.settings
```
which should always evaluate to `true`. 

So I guess this is not intended and created a fix according to the second part of the boolean expression (`lhs.rules == rhs.rules`)