### PR TITLE
Don't propose visit if the location is the same as the current visit

### DIFF
--- a/Source/WebView/turbo.js
+++ b/Source/WebView/turbo.js
@@ -57,7 +57,7 @@
         }
       }
     }
-      
+
     clearSnapshotCache() {
       if (window.Turbo) {
         Turbo.session.clearCache()
@@ -103,6 +103,9 @@
         if (Turbo.navigator.locationWithActionIsSamePage(location, options.action)) {
           Turbo.navigator.view.scrollToAnchorFromLocation(location)
           return
+        } else if (this.currentVisit?.location?.href === location.href) {
+          this.visitLocationWithOptionsAndRestorationIdentifier(location, options, Turbo.navigator.restorationIdentifier)
+          return
         }
       }
 
@@ -146,7 +149,7 @@
     visitCompleted(visit) {
       this.postMessage("visitCompleted", { identifier: visit.identifier, restorationIdentifier: visit.restorationIdentifier })
     }
-      
+
     formSubmissionStarted(formSubmission) {
       this.postMessage("formSubmissionStarted", { location: formSubmission.location.toString() })
     }


### PR DESCRIPTION
Instead, reuse the same view. This avoids some blinking when there's a redirection to the current page.

**BEFORE**

https://github.com/hotwired/turbo-ios/assets/150107/37b4c1b3-1feb-4047-b763-bc1959394a33

**AFTER**

https://github.com/hotwired/turbo-ios/assets/150107/236e0f73-c12e-4fae-9f9f-638beb51824c



