### PR TITLE
Turbo navigator feedback

### DIFF
--- a/Demo/AppDelegate.swift
+++ b/Demo/AppDelegate.swift
@@ -6,7 +6,7 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         #if DEBUG
-        Turbo.config.debugLoggingEnabled = true
+        TurboConfig.shared.debugLoggingEnabled = true
         Strada.config.debugLoggingEnabled = true
         #endif
 

--- a/Demo/NumbersViewController.swift
+++ b/Demo/NumbersViewController.swift
@@ -2,7 +2,10 @@ import UIKit
 
 /// A simple native table view controller to demonstrate loading non-Turbo screens
 /// for a visit proposal
-final class NumbersViewController: UITableViewController {
+final class NumbersViewController: UITableViewController, PathConfigurationIdentifiable {
+    
+    static var pathConfigurationIdentifier: String { "numbers" }
+    
     convenience init(url: URL, navigator: Navigator) {
         self.init(nibName: nil, bundle: nil)
         self.url = url

--- a/Demo/SceneController.swift
+++ b/Demo/SceneController.swift
@@ -69,12 +69,15 @@ extension SceneController: UIWindowSceneDelegate {
 extension SceneController: TurboNavigatorDelegate {
     func handle(proposal: VisitProposal) -> ProposalResult {
         switch proposal.viewController {
-        case "numbers":
+            
+        case NumbersViewController.pathConfigurationIdentifier:
             return .acceptCustom(NumbersViewController(url: proposal.url, navigator: navigator))
+            
         case "numbersDetail":
             let alertController = UIAlertController(title: "Number", message: "\(proposal.url.lastPathComponent)", preferredStyle: .alert)
             alertController.addAction(.init(title: "OK", style: .default, handler: nil))
             return .acceptCustom(alertController)
+            
         default:
             return .acceptCustom(TurboWebViewController(url: proposal.url))
         }

--- a/Source/Turbo Navigator/Extensions/VisitProposalExtension.swift
+++ b/Source/Turbo Navigator/Extensions/VisitProposalExtension.swift
@@ -35,6 +35,8 @@ public extension VisitProposal {
     /// A VisitProposal to `https://example.com/recipes/` will have `proposal.viewController == "recipes"`
     ///
     /// A default value is provided in case the view controller property is missing from the configuration file. This will route the default `VisitableViewController`.
+    ///
+    /// For convenience, conform `ViewController`s to `PathConfigurationIdentifiable` to couple the identifier with a view controller.
     var viewController: String {
         if let viewController = properties["view-controller"] as? String {
             return viewController

--- a/Source/Turbo Navigator/Extensions/VisitProposalExtension.swift
+++ b/Source/Turbo Navigator/Extensions/VisitProposalExtension.swift
@@ -1,14 +1,14 @@
 public extension VisitProposal {
-    var context: Navigation.Context {
+    var context: TurboNavigation.Context {
         if let rawValue = properties["context"] as? String {
-            return Navigation.Context(rawValue: rawValue) ?? .default
+            return TurboNavigation.Context(rawValue: rawValue) ?? .default
         }
         return .default
     }
 
-    var presentation: Navigation.Presentation {
+    var presentation: TurboNavigation.Presentation {
         if let rawValue = properties["presentation"] as? String {
-            return Navigation.Presentation(rawValue: rawValue) ?? .default
+            return TurboNavigation.Presentation(rawValue: rawValue) ?? .default
         }
         return .default
     }

--- a/Source/Turbo Navigator/Helpers/TurboNavigation.swift
+++ b/Source/Turbo Navigator/Helpers/TurboNavigation.swift
@@ -1,4 +1,4 @@
-public enum Navigation {
+public enum TurboNavigation {
     public enum Context: String {
         case `default`
         case modal

--- a/Source/Turbo Navigator/TurboNavigator.swift
+++ b/Source/Turbo Navigator/TurboNavigator.swift
@@ -48,10 +48,10 @@ public class TurboNavigator {
     ///   - pathConfiguration: an optional remote configuration reference
     ///   - delegate: an optional delegate to handle custom view controllers
     public convenience init(pathConfiguration: PathConfiguration? = nil, delegate: TurboNavigatorDelegate? = nil) {
-        let session = Session(webView: Turbo.config.makeWebView())
+        let session = Session(webView: TurboConfig.shared.makeWebView())
         session.pathConfiguration = pathConfiguration
 
-        let modalSession = Session(webView: Turbo.config.makeWebView())
+        let modalSession = Session(webView: TurboConfig.shared.makeWebView())
         modalSession.pathConfiguration = pathConfiguration
 
         self.init(session: session, modalSession: modalSession, delegate: delegate)

--- a/Source/Turbo.swift
+++ b/Source/Turbo.swift
@@ -1,10 +1,11 @@
 import WebKit
 
-public enum Turbo {
-    public static var config = TurboConfig()
-}
-
 public class TurboConfig {
+    
+    public static let shared = TurboConfig()
+    
+    private init() { }
+    
     public typealias WebViewBlock = (_ configuration: WKWebViewConfiguration) -> WKWebView
 
     /// Override to set a custom user agent.

--- a/Tests/Turbo Navigator/TurboNavigatorTests.swift
+++ b/Tests/Turbo Navigator/TurboNavigatorTests.swift
@@ -297,7 +297,7 @@ private class EmptyNavigationDelegate: TurboNavigationHierarchyControllerDelegat
 // MARK: - VisitProposal extension
 
 private extension VisitProposal {
-    init(path: String = "", action: VisitAction = .advance, context: Navigation.Context = .default, presentation: Navigation.Presentation = .default) {
+    init(path: String = "", action: VisitAction = .advance, context: TurboNavigation.Context = .default, presentation: TurboNavigation.Presentation = .default) {
         let url = URL(string: "https://example.com")!.appendingPathComponent(path)
         let options = VisitOptions(action: action, response: nil)
         let properties: PathProperties = [


### PR DESCRIPTION
Three minor things and one major thing. Feel free to cherry-pick any commits to your branch or merge if all commits are good!

- a code comment that I could've added to the original PR
- protocol conformance to use `PathConfigurationIdentifiable`
- renaming `Navigation` to `TurboNavigation`
- removing `Turbo` enum as it's creating a collision with the framework

The last point requires a bit of explanation: if an app that imports Turbo (the framework) has a class/struct with the same name as a turbo class/struct the compiler is unable to disambiguate which class/struct should be used.

For example, let's say the Demo app has a class named `Session`. Turbo has a class named `Session` too. In theory, there's no collision because they both exist in different namespaces. In order to use the app's Session, you'd explicitly declare it as `DemoApp.Session`. In order to use Turbo's, you'd say `Turbo.Session`.

However, since there exists an enum named `Turbo`, the compiler cannot disambiguate between:
- `Turbo.Session` (trying to call class Session from framework Turbo) 
- `Turbo.Session` (trying to access a case or property from enum Turbo).

We should avoid naming classes/structs the same as the framework. If we're set on keeping the `enum` (which I don't like), we should at least rename it to something else.

I noticed Strada is doing this too. We need to fix it there too.

Let me know what you think!
