### PR TITLE
Report form submissions via TurboNavigatorDelegate

### DIFF
--- a/Source/Turbo Navigator/TurboNavigator.swift
+++ b/Source/Turbo Navigator/TurboNavigator.swift
@@ -109,6 +109,9 @@ extension TurboNavigator: SessionDelegate {
         if session == modalSession {
             self.session.clearSnapshotCache()
         }
+        if let url = session.topmostVisitable?.visitableURL {
+            delegate.didSubmitForm(at: url)
+        }
     }
 
     public func session(_ session: Session, openExternalURL url: URL) {

--- a/Source/Turbo Navigator/TurboNavigator.swift
+++ b/Source/Turbo Navigator/TurboNavigator.swift
@@ -107,7 +107,7 @@ extension TurboNavigator: SessionDelegate {
 
     public func sessionDidStartFormSubmission(_ session: Session) {
         if let url = session.topmostVisitable?.visitableURL {
-            delegate.willSubmitForm(to: url)
+            delegate.formSubmissionDidStart(to: url)
         }
     }
 
@@ -116,7 +116,7 @@ extension TurboNavigator: SessionDelegate {
             self.session.clearSnapshotCache()
         }
         if let url = session.topmostVisitable?.visitableURL {
-            delegate.didSubmitForm(at: url)
+            delegate.formSubmissionDidFinish(at: url)
         }
     }
 

--- a/Source/Turbo Navigator/TurboNavigator.swift
+++ b/Source/Turbo Navigator/TurboNavigator.swift
@@ -105,6 +105,12 @@ extension TurboNavigator: SessionDelegate {
         hierarchyController.route(controller: controller, proposal: proposal)
     }
 
+    public func sessionDidStartFormSubmission(_ session: Session) {
+        if let url = session.topmostVisitable?.visitableURL {
+            delegate.willSubmitForm(to: url)
+        }
+    }
+
     public func sessionDidFinishFormSubmission(_ session: Session) {
         if session == modalSession {
             self.session.clearSnapshotCache()

--- a/Source/Turbo Navigator/TurboNavigatorDelegate.swift
+++ b/Source/Turbo Navigator/TurboNavigatorDelegate.swift
@@ -21,6 +21,10 @@ public protocol TurboNavigatorDelegate: AnyObject {
     /// If not implemented, default handling will be performed.
     func didReceiveAuthenticationChallenge(_ challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
     
+    /// Optional. Called before a form is submitted.
+    /// If not implemented, no action is taken.
+    func willSubmitForm(to url: URL)
+
     /// Optional. Called when a form is submitted.
     /// If not implemented, no action is taken.
     func didSubmitForm(at url: URL)
@@ -40,6 +44,8 @@ public extension TurboNavigatorDelegate {
     func didReceiveAuthenticationChallenge(_ challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         completionHandler(.performDefaultHandling, nil)
     }
-    
+
+    func willSubmitForm(to url: URL) {}
+
     func didSubmitForm(at url: URL) {}
 }

--- a/Source/Turbo Navigator/TurboNavigatorDelegate.swift
+++ b/Source/Turbo Navigator/TurboNavigatorDelegate.swift
@@ -21,13 +21,13 @@ public protocol TurboNavigatorDelegate: AnyObject {
     /// If not implemented, default handling will be performed.
     func didReceiveAuthenticationChallenge(_ challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
     
-    /// Optional. Called before a form is submitted.
+    /// Optional. Called after a form starts a submission.
     /// If not implemented, no action is taken.
-    func willSubmitForm(to url: URL)
+    func formSubmissionDidStart(to url: URL)
 
-    /// Optional. Called when a form is submitted.
+    /// Optional. Called after a form finishes a submission.
     /// If not implemented, no action is taken.
-    func didSubmitForm(at url: URL)
+    func formSubmissionDidFinish(at url: URL)
 }
 
 public extension TurboNavigatorDelegate {
@@ -45,7 +45,7 @@ public extension TurboNavigatorDelegate {
         completionHandler(.performDefaultHandling, nil)
     }
 
-    func willSubmitForm(to url: URL) {}
+    func formSubmissionDidStart(to url: URL) {}
 
-    func didSubmitForm(at url: URL) {}
+    func formSubmissionDidFinish(at url: URL) {}
 }

--- a/Source/Turbo Navigator/TurboNavigatorDelegate.swift
+++ b/Source/Turbo Navigator/TurboNavigatorDelegate.swift
@@ -20,6 +20,10 @@ public protocol TurboNavigatorDelegate: AnyObject {
     /// Optional. Respond to authentication challenge presented by web servers behing basic auth.
     /// If not implemented, default handling will be performed.
     func didReceiveAuthenticationChallenge(_ challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
+    
+    /// Optional. Called when a form is submitted.
+    /// If not implemented, no action is taken.
+    func didSubmitForm(at url: URL)
 }
 
 public extension TurboNavigatorDelegate {
@@ -36,4 +40,6 @@ public extension TurboNavigatorDelegate {
     func didReceiveAuthenticationChallenge(_ challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         completionHandler(.performDefaultHandling, nil)
     }
+    
+    func didSubmitForm(at url: URL) {}
 }


### PR DESCRIPTION
@joemasilotti I've added support for reporting form submissions via `TurboNavigatorDelegate` here, since it's something we needed for internal work. @jayohms let me know that it's functionality they expose on the Android side, so it seems like a good candidate for us here too. 
