### PR TITLE
When replacing a root in a modal context, present a new modal flow

### DIFF
--- a/Source/Turbo Navigator/TurboNavigationHierarchyController.swift
+++ b/Source/Turbo Navigator/TurboNavigationHierarchyController.swift
@@ -45,7 +45,7 @@ class TurboNavigationHierarchyController {
             case .clearAll:
                 clearAll()
             case .replaceRoot:
-                replaceRoot(with: controller)
+                replaceRoot(with: controller, via: proposal)
             case .none:
                 break // Do nothing.
             }
@@ -189,12 +189,25 @@ class TurboNavigationHierarchyController {
         delegate.refresh(navigationStack: .main)
     }
 
-    private func replaceRoot(with controller: UIViewController) {
-        navigationController.dismiss(animated: true)
-        navigationController.setViewControllers([controller], animated: true)
+    private func replaceRoot(with controller: UIViewController, via proposal: VisitProposal) {
+        
+        switch proposal.context {
+            
+        case .default:
+            navigationController.dismiss(animated: true)
+            navigationController.setViewControllers([controller], animated: true)
 
-        if let visitable = controller as? Visitable {
-            delegate.visit(visitable, on: .main, with: .init(action: .replace))
+            if let visitable = controller as? Visitable {
+                delegate.visit(visitable, on: .main, with: .init(action: .replace))
+            }
+            
+        case .modal:
+            navigationController.dismiss(animated: true) {
+                self.navigationController.present(controller, animated: true)
+                if let visitable = controller as? Visitable {
+                    self.delegate.visit(visitable, on: .modal, with: proposal.options)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Currently there's no way to jump from one modal flow to another. The app has to manually dismiss the first modal flow, then request a new modal flow by creating a new visit proposal with a modal context. Here's my proposal: make `replace_root` consider the given context.

- If given context is `default`, then behavior is unchanged: Dismiss if modal controller, then pop to root, then replace root controller on main stack.
- _If given context is `modal` then behavior is now: Dismiss if modal controller, then present a new modal._

In my mind, this makes sense since replacing a modal root restarts the flow, but I'd like to get your thoughts before I move forward with tests.