### PR TITLE
Expose a new `handle(externalURL)` function

### DIFF
--- a/Source/Turbo Navigator/Helpers/ExternalURLNavigationAction.swift
+++ b/Source/Turbo Navigator/Helpers/ExternalURLNavigationAction.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// When TurboNavigator encounters an external URL, its delegate may handle it with any of these actions.
+public enum ExternalURLNavigationAction {
+    /// Attempts to open via an embedded `SafariViewController` so the user stays in-app.
+    /// Silently fails if you pass a URL that's not `http` or `https`.
+    case openViaSafariController
+    
+    /// Attempts to open via `openURL(_:options:completionHandler)`.
+    /// This is useful if the external URL is a deeplink.
+    case openViaSystem
+    
+    /// Will do nothing with the external URL.
+    case reject
+}

--- a/Source/Turbo Navigator/TurboNavigationHierarchyController.swift
+++ b/Source/Turbo Navigator/TurboNavigationHierarchyController.swift
@@ -52,10 +52,6 @@ class TurboNavigationHierarchyController {
         }
     }
 
-    func openExternal(url: URL, navigationType: NavigationStackType) {
-        delegate.visit(externalURL: url, on: navigationType)
-    }
-
     // MARK: Private
 
     @available(*, unavailable)

--- a/Source/Turbo Navigator/TurboNavigationHierarchyController.swift
+++ b/Source/Turbo Navigator/TurboNavigationHierarchyController.swift
@@ -53,17 +53,7 @@ class TurboNavigationHierarchyController {
     }
 
     func openExternal(url: URL, navigationType: NavigationStackType) {
-        if ["http", "https"].contains(url.scheme) {
-            let safariViewController = SFSafariViewController(url: url)
-            safariViewController.modalPresentationStyle = .pageSheet
-            if #available(iOS 15.0, *) {
-                safariViewController.preferredControlTintColor = .tintColor
-            }
-            let navController = navController(for: navigationType)
-            navController.present(safariViewController, animated: true)
-        } else if UIApplication.shared.canOpenURL(url) {
-            UIApplication.shared.open(url)
-        }
+        delegate.visit(externalURL: url, on: navigationType)
     }
 
     // MARK: Private

--- a/Source/Turbo Navigator/TurboNavigationHierarchyControllerDelegate.swift
+++ b/Source/Turbo Navigator/TurboNavigationHierarchyControllerDelegate.swift
@@ -5,6 +5,5 @@ import WebKit
 /// or to render a native controller instead of a Turbo web visit.
 protocol TurboNavigationHierarchyControllerDelegate: AnyObject {
     func visit(_ : Visitable, on: TurboNavigationHierarchyController.NavigationStackType, with: VisitOptions)
-    func visit(externalURL: URL, on: TurboNavigationHierarchyController.NavigationStackType)
     func refresh(navigationStack: TurboNavigationHierarchyController.NavigationStackType)
 }

--- a/Source/Turbo Navigator/TurboNavigationHierarchyControllerDelegate.swift
+++ b/Source/Turbo Navigator/TurboNavigationHierarchyControllerDelegate.swift
@@ -5,6 +5,6 @@ import WebKit
 /// or to render a native controller instead of a Turbo web visit.
 protocol TurboNavigationHierarchyControllerDelegate: AnyObject {
     func visit(_ : Visitable, on: TurboNavigationHierarchyController.NavigationStackType, with: VisitOptions)
-    
+    func visit(externalURL: URL, on: TurboNavigationHierarchyController.NavigationStackType)
     func refresh(navigationStack: TurboNavigationHierarchyController.NavigationStackType)
 }

--- a/Source/Turbo Navigator/TurboNavigator.swift
+++ b/Source/Turbo Navigator/TurboNavigator.swift
@@ -146,10 +146,32 @@ extension TurboNavigator: SessionDelegate {
 // MARK: - TurboNavigationHierarchyControllerDelegate
 
 extension TurboNavigator: TurboNavigationHierarchyControllerDelegate {
+    
     func visit(_ controller: Visitable, on navigationStack: TurboNavigationHierarchyController.NavigationStackType, with: VisitOptions) {
         switch navigationStack {
-            case .main: session.visit(controller, action: .advance)
-            case .modal: modalSession.visit(controller, action: .advance)
+        case .main: session.visit(controller, action: .advance)
+        case .modal: modalSession.visit(controller, action: .advance)
+        }
+    }
+    
+    func visit(externalURL: URL, on: TurboNavigationHierarchyController.NavigationStackType) {
+        
+        switch delegate.handle(externalURL: externalURL) {
+            
+        case .openViaSystem:
+            UIApplication.shared.open(externalURL)
+            
+        case .openViaSafariController:
+            let safariViewController = SFSafariViewController(url: externalURL)
+            safariViewController.modalPresentationStyle = .pageSheet
+            if #available(iOS 15.0, *) {
+                safariViewController.preferredControlTintColor = .tintColor
+            }
+            
+            rootViewController.present(safariViewController, animated: true)
+            
+        case .reject:
+            return
         }
     }
 

--- a/Source/Turbo Navigator/TurboNavigator.swift
+++ b/Source/Turbo Navigator/TurboNavigator.swift
@@ -168,7 +168,7 @@ extension TurboNavigator: TurboNavigationHierarchyControllerDelegate {
                 safariViewController.preferredControlTintColor = .tintColor
             }
             
-            rootViewController.present(safariViewController, animated: true)
+            activeNavigationController.present(safariViewController, animated: true)
             
         case .reject:
             return

--- a/Source/Turbo Navigator/TurboNavigator.swift
+++ b/Source/Turbo Navigator/TurboNavigator.swift
@@ -111,9 +111,25 @@ extension TurboNavigator: SessionDelegate {
         }
     }
 
-    public func session(_ session: Session, openExternalURL url: URL) {
-        let navigationType: TurboNavigationHierarchyController.NavigationStackType = session === modalSession ? .modal : .main
-        hierarchyController.openExternal(url: url, navigationType: navigationType)
+    public func session(_ session: Session, openExternalURL externalURL: URL) {
+        
+        switch delegate.handle(externalURL: externalURL) {
+            
+        case .openViaSystem:
+            UIApplication.shared.open(externalURL)
+            
+        case .openViaSafariController:
+            let safariViewController = SFSafariViewController(url: externalURL)
+            safariViewController.modalPresentationStyle = .pageSheet
+            if #available(iOS 15.0, *) {
+                safariViewController.preferredControlTintColor = .tintColor
+            }
+            
+            activeNavigationController.present(safariViewController, animated: true)
+            
+        case .reject:
+            return
+        }
     }
 
     public func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error) {
@@ -151,27 +167,6 @@ extension TurboNavigator: TurboNavigationHierarchyControllerDelegate {
         switch navigationStack {
         case .main: session.visit(controller, action: .advance)
         case .modal: modalSession.visit(controller, action: .advance)
-        }
-    }
-    
-    func visit(externalURL: URL, on: TurboNavigationHierarchyController.NavigationStackType) {
-        
-        switch delegate.handle(externalURL: externalURL) {
-            
-        case .openViaSystem:
-            UIApplication.shared.open(externalURL)
-            
-        case .openViaSafariController:
-            let safariViewController = SFSafariViewController(url: externalURL)
-            safariViewController.modalPresentationStyle = .pageSheet
-            if #available(iOS 15.0, *) {
-                safariViewController.preferredControlTintColor = .tintColor
-            }
-            
-            activeNavigationController.present(safariViewController, animated: true)
-            
-        case .reject:
-            return
         }
     }
 

--- a/Source/Turbo Navigator/TurboNavigatorDelegate.swift
+++ b/Source/Turbo Navigator/TurboNavigatorDelegate.swift
@@ -12,6 +12,8 @@ public protocol TurboNavigatorDelegate: AnyObject {
     /// - Returns: how to react to the visit proposal
     func handle(proposal: VisitProposal) -> ProposalResult
 
+    func handle(externalURL: URL) -> ExternalURLNavigationAction
+    
     /// Optional. An error occurred loading the request, present it to the user.
     /// Retry the request by executing the closure.
     /// If not implemented, will present the error's localized description and a Retry button.
@@ -25,6 +27,10 @@ public protocol TurboNavigatorDelegate: AnyObject {
 public extension TurboNavigatorDelegate {
     func handle(proposal: VisitProposal) -> ProposalResult {
         .accept
+    }
+    
+    func handle(externalURL: URL) -> ExternalURLNavigationAction {
+        .openViaSystem
     }
 
     func visitableDidFailRequest(_ visitable: Visitable, error: Error, retry: @escaping RetryBlock) {

--- a/Source/Turbo Navigator/TurboNavigatorDelegate.swift
+++ b/Source/Turbo Navigator/TurboNavigatorDelegate.swift
@@ -30,7 +30,7 @@ public extension TurboNavigatorDelegate {
     }
     
     func handle(externalURL: URL) -> ExternalURLNavigationAction {
-        .openViaSystem
+        .openViaSafariController
     }
 
     func visitableDidFailRequest(_ visitable: Visitable, error: Error, retry: @escaping RetryBlock) {


### PR DESCRIPTION
I found two issues that I think need solving in `TurboNavigationHierarchyController.openExternal(url: URL, navigationType: NavigationStackType)`.

1. Its behavior is hard-coded. It should be moved up to the sensible defaults of TurboNavigator.
2. It cannot handle external URLs that are not http/https nor available to `UIApplication` (for example, a deeplink to another app).

For the hard-coded behavior, I've moved the behavior to TurboNavigator and exposed another function in `TurboNavigatorDelegate`, `handle(externalURL:) -> ExternalURLNavigationAction`. The default I chose is to send it to the system so it opens Safari (the app). The framework consumer may choose to open it in-app via a SafariController or it can choose to handle it on its own, maybe alerting the user before navigating away.

The delegation pattern solves handling non-http/https URLs. We'll report all external URLs to `TurboNavigator`'s delegate, http/https or otherwise.

Again, I'm opening a draft so we can discuss it. Happy to change the approach and add unit tests once we're ok with it.