### PR TITLE
Swift-ify Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ You can also integrate the framework manually if your prefer, such as by adding 
 - [Path Configuration](Docs/PathConfiguration.md)
 - [Migration](Docs/Migration.md)
 - [Advanced](Docs/Advanced.md)
+- [TurboNavigator](Docs/TurboNavigator.md)
 
 ## Contributing
 

--- a/Source/Turbo Navigator/Extensions/VisitProposalExtension.swift
+++ b/Source/Turbo Navigator/Extensions/VisitProposalExtension.swift
@@ -26,7 +26,7 @@ public extension VisitProposal {
     ///
     /// For example, given the following configuration file:
     ///
-    /// ```
+    /// ```json
     /// {
     ///   "rules": [
     ///     {
@@ -41,11 +41,13 @@ public extension VisitProposal {
     /// }
     /// ```
     ///
-    /// A VisitProposal to `https://example.com/recipes/` will have `proposal.viewController == "recipes"`
+    /// A VisitProposal to `https://example.com/recipes/` will have 
+    /// ```swift
+    /// proposal.viewController == "recipes"
+    /// ```
     ///
-    /// A default value is provided in case the view controller property is missing from the configuration file. This will route the default `VisitableViewController`.
-    ///
-    /// For convenience, conform `ViewController`s to `PathConfigurationIdentifiable` to couple the identifier with a view controller.
+    /// - Important: A default value is provided in case the view controller property is missing from the configuration file. This will route the default `VisitableViewController`.
+    /// - Note: A `ViewController` must conform to `PathConfigurationIdentifiable` to couple the identifier with a view controlelr.
     var viewController: String {
         if let viewController = properties["view-controller"] as? String {
             return viewController

--- a/Source/Turbo Navigator/Helpers/PathConfigurationIdentifiable.swift
+++ b/Source/Turbo Navigator/Helpers/PathConfigurationIdentifiable.swift
@@ -1,18 +1,20 @@
 import UIKit
 
-/// As a convenience, your view controller may conform to `PathConfigurationIdentifiable`.
-/// You may then use the view controller's `pathConfigurationIdentifier` property instead of `proposal.url` when deciding how to handle a proposal. See `VisitProposal.viewController` on how to use this in your configuration file.
+/// As a convenience, a view controller may conform to `PathConfigurationIdentifiable`.
 ///
-/// ```
+/// Use a view controller's `pathConfigurationIdentifier` property instead of `proposal.url` when deciding how to handle a proposal.
+///
+/// ```swift
 /// func handle(proposal: VisitProposal) -> ProposalResult {
 ///    switch proposal.viewController {
 ///    case RecipeViewController.pathConfigurationIdentifier:
-///        return .acceptCustom(RecipeViewController.new)
+///        return .acceptCustom(RecipeViewController())
 ///    default:
 ///        return .accept
 ///    }
 /// }
 /// ```
+/// - Note: See `VisitProposal.viewController` on how to use this in your configuration file.
 public protocol PathConfigurationIdentifiable: UIViewController {
     static var pathConfigurationIdentifier: String { get }
 }

--- a/Source/Turbo Navigator/Helpers/ProposalResult.swift
+++ b/Source/Turbo Navigator/Helpers/ProposalResult.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-/// Return from `handle(proposal:)` to route a custom controller.
+/// Return from `TurboNavigatorDelegate.handle(proposal:)` to route a custom controller.
 public enum ProposalResult: Equatable {
     /// Route a `VisitableViewController`.
     case accept

--- a/Source/Turbo Navigator/TurboNavigator.swift
+++ b/Source/Turbo Navigator/TurboNavigator.swift
@@ -6,7 +6,7 @@ import WebKit
 class DefaultTurboNavigatorDelegate: NSObject, TurboNavigatorDelegate {}
 
 /// Handles navigation to new URLs using the following rules:
-/// https://github.com/hotwired/turbo-ios/Docs/TurboNavigator.md
+/// [Turbo Navigator Handled Flows](https://github.com/hotwired/turbo-ios/Docs/TurboNavigator.md)
 public class TurboNavigator {
     public unowned var delegate: TurboNavigatorDelegate
 
@@ -14,6 +14,7 @@ public class TurboNavigator {
     public var activeNavigationController: UINavigationController { hierarchyController.activeNavigationController }
 
     /// Set to handle customize behavior of the `WKUIDelegate`.
+    ///
     /// Subclass `TurboWKUIController` to add additional behavior alongside alert/confirm dialogs.
     /// Or, provide a completely custom `WKUIDelegate` implementation.
     public var webkitUIDelegate: WKUIDelegate? {
@@ -24,11 +25,12 @@ public class TurboNavigator {
     }
 
     /// Default initializer requiring preconfigured `Session` instances.
-    /// User `init(pathConfiguration:delegate)` to only provide a `PathConfiguration`.
+    ///
+    /// User `init(pathConfiguration:delegate:)` to only provide a `PathConfiguration`.
     /// - Parameters:
     ///   - session: the main `Session`
     ///   - modalSession: the `Session` used for the modal navigation controller
-    ///   - delegate: an optional delegate to handle custom view controllers
+    ///   - delegate: _optional:_ delegate to handle custom view controllers
     public init(session: Session, modalSession: Session, delegate: TurboNavigatorDelegate? = nil) {
         self.session = session
         self.modalSession = modalSession
@@ -45,8 +47,8 @@ public class TurboNavigator {
 
     /// Convenience initializer that doesn't require manually creating `Session` instances.
     /// - Parameters:
-    ///   - pathConfiguration: an optional remote configuration reference
-    ///   - delegate: an optional delegate to handle custom view controllers
+    ///   - pathConfiguration: _optional:_ remote configuration reference
+    ///   - delegate: _optional:_ delegate to handle custom view controllers
     public convenience init(pathConfiguration: PathConfiguration? = nil, delegate: TurboNavigatorDelegate? = nil) {
         let session = Session(webView: Turbo.config.makeWebView())
         session.pathConfiguration = pathConfiguration

--- a/Source/Turbo Navigator/TurboNavigatorDelegate.swift
+++ b/Source/Turbo Navigator/TurboNavigatorDelegate.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+/// Contract for handling navigation requests and actions
+/// - Note: Methods  are __optional__ by default implementation in ``TurboNavigatorDelegate`` extension.
 public protocol TurboNavigatorDelegate: AnyObject {
     typealias RetryBlock = () -> Void
 
@@ -11,7 +13,6 @@ public protocol TurboNavigatorDelegate: AnyObject {
     ///
     /// - Parameter proposal: `VisitProposal` navigation destination
     /// - Returns:`ProposalResult` - how to react to the visit proposal
-    /// - Note: optional
     func handle(proposal: VisitProposal) -> ProposalResult
 
     func handle(externalURL: URL) -> ExternalURLNavigationAction
@@ -19,12 +20,10 @@ public protocol TurboNavigatorDelegate: AnyObject {
     /// An error occurred loading the request, present it to the user.
     /// Retry the request by executing the closure.
     /// - Important: If not implemented, will present the error's localized description and a Retry button.
-    /// - Note: optional
     func visitableDidFailRequest(_ visitable: Visitable, error: Error, retry: @escaping RetryBlock)
 
     /// Respond to authentication challenge presented by web servers behing basic auth.
     /// If not implemented, default handling will be performed.
-    /// - Note: optional
     func didReceiveAuthenticationChallenge(_ challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
 }
 

--- a/Source/Turbo Navigator/TurboNavigatorDelegate.swift
+++ b/Source/Turbo Navigator/TurboNavigatorDelegate.swift
@@ -3,24 +3,28 @@ import Foundation
 public protocol TurboNavigatorDelegate: AnyObject {
     typealias RetryBlock = () -> Void
 
-    /// Optional. Accept or reject a visit proposal.
-    /// If accepted, you may provide a view controller to be displayed, otherwise a new `VisitableViewController` is displayed.
-    /// If rejected, no changes to navigation occur.
-    /// If not implemented, proposals are accepted and a new `VisitableViewController` is displayed.
+    /// Accept or reject a visit proposal.
+    /// There are three `ProposalResult` cases:
+    ///    - term `accept`: Proposals are accepted and a new `VisitableViewController` is displayed.
+    ///    - term `acceptCustom(UIViewController)`: You may provide a view controller to be displayed, otherwise a new `VisitableViewController` is displayed.
+    ///    - term `reject`: No changes to navigation occur.
     ///
-    /// - Parameter proposal: navigation destination
-    /// - Returns: how to react to the visit proposal
+    /// - Parameter proposal: `VisitProposal` navigation destination
+    /// - Returns:`ProposalResult` - how to react to the visit proposal
+    /// - Note: optional
     func handle(proposal: VisitProposal) -> ProposalResult
 
     func handle(externalURL: URL) -> ExternalURLNavigationAction
     
-    /// Optional. An error occurred loading the request, present it to the user.
+    /// An error occurred loading the request, present it to the user.
     /// Retry the request by executing the closure.
-    /// If not implemented, will present the error's localized description and a Retry button.
+    /// - Important: If not implemented, will present the error's localized description and a Retry button.
+    /// - Note: optional
     func visitableDidFailRequest(_ visitable: Visitable, error: Error, retry: @escaping RetryBlock)
 
-    /// Optional. Respond to authentication challenge presented by web servers behing basic auth.
+    /// Respond to authentication challenge presented by web servers behing basic auth.
     /// If not implemented, default handling will be performed.
+    /// - Note: optional
     func didReceiveAuthenticationChallenge(_ challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
 }
 

--- a/Source/Turbo.swift
+++ b/Source/Turbo.swift
@@ -8,7 +8,7 @@ public class TurboConfig {
     public typealias WebViewBlock = (_ configuration: WKWebViewConfiguration) -> WKWebView
 
     /// Override to set a custom user agent.
-    /// Include "Turbo Native" to use `turbo_native_app?` on your Rails server.
+    /// - Important: Include "Turbo Native" to use `turbo_native_app?` on your Rails server.
     public var userAgent = "Turbo Native iOS"
 
     /// Optionally customize the web views used by each Turbo Session.


### PR DESCRIPTION
Mostly covers TurboNavigator Documentation, with the exception of a couple files. 


Made some small changes to the project's documentation with hopes to align more with Swift's DocC. Although most are esthetic changes .
You may preview these changes in XCode by `Option` + `Click` on element with doc comments.

cc: @joemasilotti - From previous PR on [TurboNavigator](https://github.com/joemasilotti/TurboNavigator/pull/78) repo 