### PR TITLE
Allow framework users to navigate to an external URL using TurboNavigator

### DIFF
--- a/Source/Turbo Navigator/TurboNavigator.swift
+++ b/Source/Turbo Navigator/TurboNavigator.swift
@@ -75,6 +75,31 @@ public class TurboNavigator {
         guard let controller = controller(for: proposal) else { return }
         hierarchyController.route(controller: controller, proposal: proposal)
     }
+    
+    /// Allows programmatic navigation of external URLs.
+    ///
+    /// - Parameters:
+    ///   - externalURL: the URL to navigate to
+    ///   - via: navigation action
+    public func open(externalURL: URL, via: ExternalURLNavigationAction) {
+        switch via {
+            
+        case .openViaSystem:
+            UIApplication.shared.open(externalURL)
+            
+        case .openViaSafariController:
+            let safariViewController = SFSafariViewController(url: externalURL)
+            safariViewController.modalPresentationStyle = .pageSheet
+            if #available(iOS 15.0, *) {
+                safariViewController.preferredControlTintColor = .tintColor
+            }
+            
+            activeNavigationController.present(safariViewController, animated: true)
+            
+        case .reject:
+            return
+        }
+    }
 
     let session: Session
     let modalSession: Session
@@ -121,22 +146,9 @@ extension TurboNavigator: SessionDelegate {
     }
 
     public func session(_ session: Session, openExternalURL externalURL: URL) {
-        switch delegate.handle(externalURL: externalURL) {
-        case .openViaSystem:
-            UIApplication.shared.open(externalURL)
-
-        case .openViaSafariController:
-            let safariViewController = SFSafariViewController(url: externalURL)
-            safariViewController.modalPresentationStyle = .pageSheet
-            if #available(iOS 15.0, *) {
-                safariViewController.preferredControlTintColor = .tintColor
-            }
-
-            activeNavigationController.present(safariViewController, animated: true)
-
-        case .reject:
-            return
-        }
+        let decision = delegate.handle(externalURL: externalURL)
+        open(externalURL: externalURL,
+             via: decision)
     }
 
     public func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error) {

--- a/Source/Turbo Navigator/TurboNavigator.swift
+++ b/Source/Turbo Navigator/TurboNavigator.swift
@@ -81,7 +81,7 @@ public class TurboNavigator {
     /// - Parameters:
     ///   - externalURL: the URL to navigate to
     ///   - via: navigation action
-    public func open(externalURL: URL, via: ExternalURLNavigationAction) {
+    public func open(externalURL: URL, _ via: ExternalURLNavigationAction) {
         switch via {
             
         case .openViaSystem:

--- a/Source/Turbo Navigator/TurboNavigator.swift
+++ b/Source/Turbo Navigator/TurboNavigator.swift
@@ -147,8 +147,7 @@ extension TurboNavigator: SessionDelegate {
 
     public func session(_ session: Session, openExternalURL externalURL: URL) {
         let decision = delegate.handle(externalURL: externalURL)
-        open(externalURL: externalURL,
-             via: decision)
+        open(externalURL: externalURL, decision)
     }
 
     public func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error) {

--- a/Source/Turbo Navigator/TurboNavigator.swift
+++ b/Source/Turbo Navigator/TurboNavigator.swift
@@ -76,7 +76,7 @@ public class TurboNavigator {
         hierarchyController.route(controller: controller, proposal: proposal)
     }
     
-    /// Allows programmatic navigation of external URLs.
+    /// Navigate to an external URL.
     ///
     /// - Parameters:
     ///   - externalURL: the URL to navigate to


### PR DESCRIPTION
Exposing this function is a convenience so that, for common use cases, a framework user can open an external URL by using TurboNavigator, instead of implementing these functions themselves.

Session behavior when an external URL is found is unchanged.

