### PR TITLE
Allow proposed modal to dismiss a currently presented modal

### DIFF
--- a/Source/Turbo Navigator/Extensions/VisitProposalExtension.swift
+++ b/Source/Turbo Navigator/Extensions/VisitProposalExtension.swift
@@ -26,6 +26,14 @@ public extension VisitProposal {
         properties["pull_to_refresh_enabled"] as? Bool ?? true
     }
 
+    /// Allows a proposal to dismiss a modal if it's present.
+    /// This is useful if:
+    /// - Modal A is current presented
+    /// - Modal B is proposed and it does not want to be a part Modal A's navigation controller.
+    var alwaysDismiss: Bool {
+        properties["always_dismiss"] as? Bool ?? false
+    }
+
     /// Used to identify a custom native view controller if provided in the path configuration properties of a given pattern.
     ///
     /// For example, given the following configuration file:

--- a/Source/Turbo Navigator/TurboNavigationHierarchyController.swift
+++ b/Source/Turbo Navigator/TurboNavigationHierarchyController.swift
@@ -82,16 +82,26 @@ class TurboNavigationHierarchyController {
                 delegate.visit(visitable, on: .main, with: proposal.options)
             }
         case .modal:
-            if navigationController.presentedViewController != nil, !modalNavigationController.isBeingDismissed {
-                pushOrReplace(on: modalNavigationController, with: controller, via: proposal)
+            if proposal.alwaysDismiss {
+                navigationController.dismiss(animated: true) {
+                    self.modalNavigate(with: controller, via: proposal)
+                }
             } else {
-                modalNavigationController.setViewControllers([controller], animated: true)
-                modalNavigationController.setModalPresentationStyle(via: proposal)
-                navigationController.present(modalNavigationController, animated: true)
+                modalNavigate(with: controller, via: proposal)
             }
-            if let visitable = controller as? Visitable {
-                delegate.visit(visitable, on: .modal, with: proposal.options)
-            }
+        }
+    }
+    
+    private func modalNavigate(with controller: UIViewController, via proposal: VisitProposal) {
+        if navigationController.presentedViewController != nil, !modalNavigationController.isBeingDismissed {
+            pushOrReplace(on: modalNavigationController, with: controller, via: proposal)
+        } else {
+            modalNavigationController.setViewControllers([controller], animated: true)
+            modalNavigationController.setModalPresentationStyle(via: proposal)
+            navigationController.present(modalNavigationController, animated: true)
+        }
+        if let visitable = controller as? Visitable {
+            delegate.visit(visitable, on: .modal, with: proposal.options)
         }
     }
 


### PR DESCRIPTION
This is the alternative to https://github.com/hotwired/turbo-ios/pull/164.

> Currently there's no way to jump from one modal flow to another. The app has to manually dismiss the first modal flow, then request a new modal flow by creating a new visit proposal with a modal context. 

Adding an "always_dismiss" key allows us to modify the proposal so that the above is now possible. If Modal A is presented, and Modal B is proposed, Modal B can now dismiss Modal A before being presented by setting "always_dismiss" to true.