### PR TITLE
Fix snapshot cache issue

### DIFF
--- a/Source/Session/Session.swift
+++ b/Source/Session/Session.swift
@@ -87,7 +87,7 @@ public class Session: NSObject {
         topmostVisit = currentVisit
     }
     
-    public func clearSnapshotCache() {
+    @objc public func clearSnapshotCache() {
         bridge.clearSnapshotCache()
     }
 
@@ -221,7 +221,7 @@ extension Session: VisitableDelegate {
         } else if visitable === currentVisit.visitable && currentVisit.state == .started {
             // Navigating forward - complete navigation early
             completeNavigationForCurrentVisit()
-        } else if visitable !== topmostVisit.visitable {
+        } else if visitable !== topmostVisit.visitable && !visitable.visitableViewController.isMovingToParent {
             // Navigating backward
             visit(visitable, action: .restore)
         }

--- a/Source/Turbo Navigator/TurboNavigator.swift
+++ b/Source/Turbo Navigator/TurboNavigator.swift
@@ -113,7 +113,7 @@ extension TurboNavigator: SessionDelegate {
 
     public func sessionDidFinishFormSubmission(_ session: Session) {
         if session == modalSession {
-            self.session.clearSnapshotCache()
+            self.session.perform(#selector(Session.clearSnapshotCache), with: nil, afterDelay: 1)
         }
         if let url = session.topmostVisitable?.visitableURL {
             delegate.formSubmissionDidFinish(at: url)

--- a/Source/WebView/turbo.js
+++ b/Source/WebView/turbo.js
@@ -103,6 +103,9 @@
         if (Turbo.navigator.locationWithActionIsSamePage(location, options.action)) {
           Turbo.navigator.view.scrollToAnchorFromLocation(location)
           return
+        } else if (this.currentVisit?.location?.href === location.href) {
+          this.visitLocationWithOptionsAndRestorationIdentifier(location, options, Turbo.navigator.restorationIdentifier)
+          return
         }
       }
 


### PR DESCRIPTION
This PR is an attempt to fix an issue where the snapshot cache doesn't get cleared.

To recreate:

1. Present a modal that submits a form - this calls `clearSnapshotCache()
1. Navigate back

Expected behavior:

The flash message appears on the redirected to page. Navigating back reloads the page from the server.

Actual behavior:

The flash message is "eaten" by Rails because turbo-ios makes two requests to the show page. Navigating back shows the stale content because the snapshot cache was never cleared.

---

I think we have a race condition. I'm not able to nail down why `Turbo.session.clearCache()` seems to silently fail in this scenario but I'm guessing it has something to do with the view not being 100% "visible". As in, the modal might be the active web view so this JavaScript call might not fully execute.

This PR makes two changes. The changes to `Session` fix the flash message by no longer performing the visit twice. I'd like a second set of eyes on this to make sure I'm not overlooking something.

The second change, in `TurboNavigator`, is a hack. I think that delaying the clearing of the cache by 1 second fixes the issue because the non-modal web view has become "visible" again. Obviously, hard-coding a one second delay is ripe for future issues. Does anyone have any ideas on how we could handle this better?