### PR TITLE
Add `reloadActiveSession`

### DIFF
--- a/Source/Turbo Navigator/TurboNavigationHierarchyController.swift
+++ b/Source/Turbo Navigator/TurboNavigationHierarchyController.swift
@@ -11,6 +11,10 @@ class TurboNavigationHierarchyController {
         navigationController.presentedViewController != nil ? modalNavigationController : navigationController
     }
 
+    var activeNavigationStack: NavigationStackType {
+        navigationController.presentedViewController != nil ? .modal : .main
+    }
+    
     enum NavigationStackType {
         case main
         case modal

--- a/Source/Turbo Navigator/TurboNavigator.swift
+++ b/Source/Turbo Navigator/TurboNavigator.swift
@@ -104,8 +104,16 @@ public class TurboNavigator {
         }
     }
 
+    public func reloadActiveSession() {
+        activeSession.reload()
+    }
+    
     let session: Session
     let modalSession: Session
+    
+    private var activeSession: Session {
+        hierarchyController.activeNavigationStack == .modal ? modalSession : session
+    }
 
     /// Modifies a UINavigationController according to visit proposals.
     lazy var hierarchyController = TurboNavigationHierarchyController(delegate: self)


### PR DESCRIPTION
This PR will add the function `reloadActiveSession` to the TurboNavigator, to reload the currently active session (modal or main) without the need of performing a new visit or navigation.      

If you wanted to reload the active session before this change, you first had to find out whether the modal or main session was active. 
In addition, you had to pass in the sessions during initialization in order to reload it if desired.    

This changes would come in handy, if you wanna reload the active session, after the app comes back to foreground or for handling internet connection loss. 
