### PR TITLE
Do not show spinners or screenshots during refresh visits

### DIFF
--- a/Source/Session/Session.swift
+++ b/Source/Session/Session.swift
@@ -164,12 +164,16 @@ extension Session: VisitDelegate {
     }
 
     func visitWillStart(_ visit: Visit) {
+        guard !visit.isPageRefresh else { return }
+
         visit.visitable.showVisitableScreenshot()
         activateVisitable(visit.visitable)
     }
 
     func visitDidStart(_ visit: Visit) {
         guard !visit.hasCachedSnapshot else { return }
+        guard !visit.isPageRefresh else { return }
+
         visit.visitable.showVisitableActivityIndicator()
     }
 

--- a/Source/Visit/JavaScriptVisit.swift
+++ b/Source/Visit/JavaScriptVisit.swift
@@ -34,10 +34,11 @@ final class JavaScriptVisit: Visit {
 }
 
 extension JavaScriptVisit: WebViewVisitDelegate {
-    func webView(_ webView: WebViewBridge, didStartVisitWithIdentifier identifier: String, hasCachedSnapshot: Bool) {
-        log("didStartVisitWithIdentifier", ["identifier": identifier, "hasCachedSnapshot": hasCachedSnapshot])
+  func webView(_ webView: WebViewBridge, didStartVisitWithIdentifier identifier: String, hasCachedSnapshot: Bool, isPageRefresh: Bool) {
+    log("didStartVisitWithIdentifier", ["identifier": identifier, "hasCachedSnapshot": hasCachedSnapshot, "isPageRefresh": isPageRefresh])
         self.identifier = identifier
         self.hasCachedSnapshot = hasCachedSnapshot
+        self.isPageRefresh = isPageRefresh
         
         delegate?.visitDidStart(self)
     }

--- a/Source/Visit/Visit.swift
+++ b/Source/Visit/Visit.swift
@@ -18,6 +18,7 @@ class Visit: NSObject {
     let location: URL
     
     var hasCachedSnapshot: Bool = false
+    var isPageRefresh: Bool = false
     private(set) var state: VisitState
     
     init(visitable: Visitable, options: VisitOptions, bridge: WebViewBridge) {

--- a/Source/WebView/WebViewBridge.swift
+++ b/Source/WebView/WebViewBridge.swift
@@ -14,7 +14,7 @@ protocol WebViewPageLoadDelegate: AnyObject {
 }
 
 protocol WebViewVisitDelegate: AnyObject {
-    func webView(_ webView: WebViewBridge, didStartVisitWithIdentifier identifier: String, hasCachedSnapshot: Bool)
+    func webView(_ webView: WebViewBridge, didStartVisitWithIdentifier identifier: String, hasCachedSnapshot: Bool, isPageRefresh: Bool)
     func webView(_ webView: WebViewBridge, didStartRequestForVisitWithIdentifier identifier: String, date: Date)
     func webView(_ webView: WebViewBridge, didCompleteRequestForVisitWithIdentifier identifier: String)
     func webView(_ webView: WebViewBridge, didFailRequestForVisitWithIdentifier identifier: String, statusCode: Int)
@@ -126,7 +126,7 @@ extension WebViewBridge: ScriptMessageHandlerDelegate {
         case .visitProposed:
             delegate?.webView(self, didProposeVisitToLocation: message.location!, options: message.options!)
         case .visitStarted:
-            visitDelegate?.webView(self, didStartVisitWithIdentifier: message.identifier!, hasCachedSnapshot: message.data["hasCachedSnapshot"] as! Bool)
+            visitDelegate?.webView(self, didStartVisitWithIdentifier: message.identifier!, hasCachedSnapshot: message.data["hasCachedSnapshot"] as! Bool, isPageRefresh: message.data["isPageRefresh"] as! Bool)
         case .visitRequestStarted:
             visitDelegate?.webView(self, didStartRequestForVisitWithIdentifier: message.identifier!, date: message.date)
         case .visitRequestCompleted:

--- a/Source/WebView/turbo.js
+++ b/Source/WebView/turbo.js
@@ -103,6 +103,9 @@
         if (Turbo.navigator.locationWithActionIsSamePage(location, options.action)) {
           Turbo.navigator.view.scrollToAnchorFromLocation(location)
           return
+        } else if (this.currentVisit?.location?.href === location.href) {
+          this.visitLocationWithOptionsAndRestorationIdentifier(location, options, Turbo.navigator.restorationIdentifier)
+          return
         }
       }
 
@@ -116,7 +119,7 @@
 
     visitStarted(visit) {
       this.currentVisit = visit
-      this.postMessage("visitStarted", { identifier: visit.identifier, hasCachedSnapshot: visit.hasCachedSnapshot() })
+      this.postMessage("visitStarted", { identifier: visit.identifier, hasCachedSnapshot: visit.hasCachedSnapshot(), isPageRefresh: visit.isPageRefresh })
       this.issueRequestForVisitWithIdentifier(visit.identifier)
       this.changeHistoryForVisitWithIdentifier(visit.identifier)
       this.loadCachedSnapshotForVisitWithIdentifier(visit.identifier)


### PR DESCRIPTION
Fixes #175, #136 and #160.

Building on the change in #160 by @afcapel, this tracks if a visit is a page refresh and skips showing screenshot and activity spinners. The WebView is still activated and can be scrolled during the refresh visits as expected.

Previously the WebView would be 'blanked', become unresponsive and spinners would be shown.

The behavior during refreshes after this change (no spinners or blank webview and the view is still scrollable and active):

https://github.com/hotwired/turbo-ios/assets/195925/fe7e2095-1be4-4216-b429-6ed6076e7c5c
