### PR TITLE
Update adapter to use `Navigator#locationWithActionIsPageRefresh`

### DIFF
--- a/Source/WebView/turbo.js
+++ b/Source/WebView/turbo.js
@@ -99,25 +99,17 @@
     // Adapter interface
 
     visitProposedToLocation(location, options) {
-      if (window.Turbo) {
-        if (Turbo.navigator.locationWithActionIsSamePage(location, options.action)) {
-          this.postMessage("visitProposalScrollingToAnchor", { location: location.toString(), options: options })
-          Turbo.navigator.view.scrollToAnchorFromLocation(location)
-
-          return
-        }
-        
-        if (this.isPageRefreshWithBackwardsCompatibility(location, options.action)) {
-          // Refresh the page without native proposal
-          this.postMessage("visitProposalRefreshingPage", { location: location.toString(), options: options })
-          this.visitLocationWithOptionsAndRestorationIdentifier(location, options, Turbo.navigator.restorationIdentifier)
-
-          return
-        }
+      if (window.Turbo && Turbo.navigator.locationWithActionIsSamePage(location, options.action)) {
+        this.postMessage("visitProposalScrollingToAnchor", { location: location.toString(), options: options })
+        Turbo.navigator.view.scrollToAnchorFromLocation(location)
+      } else if (this.isPageRefreshWithBackwardsCompatibility(location, options.action)) {
+        // Refresh the page without native proposal
+        this.postMessage("visitProposalRefreshingPage", { location: location.toString(), options: options })
+        this.visitLocationWithOptionsAndRestorationIdentifier(location, options, Turbo.navigator.restorationIdentifier)
+      } else {
+        // Propose the visit
+        this.postMessage("visitProposed", { location: location.toString(), options: options })
       }
-
-      // Propose the visit
-      this.postMessage("visitProposed", { location: location.toString(), options: options })
     }
 
     // Turbolinks 5


### PR DESCRIPTION
Related PR: #178 and comment in https://github.com/hotwired/turbo-ios/pull/178#discussion_r1500266398

As mentioned in [this comment](https://github.com/hotwired/turbo-ios/pull/178#discussion_r1500266398) there's a risk that the logic in the native adapter to determine if a proposed visit would be a page refresh, is different from Turbo causing inconsitencies. Today, it actually is - eg. an `advance` proposal to the same location would be considered a page refresh in Turbo iOS, but not in Turbo. This feels off.

Instead, Turbo could export a `locationWithActionIsPageRefresh` method which the native adapters will call. This ensures the responsibility of determining when an action is a page refresh is with Turbo and future-proofs the native adapters as well.

This requires a change to Turbo making the `Navigator#locationWithActionIsPageRefresh` available. I've opened up a corresponding PR here: https://github.com/hotwired/turbo/pull/1201

/CC @jayohms @afcapel