### PR TITLE
Snapshot and deactivate Visitable during it's lifecycle

### DIFF
--- a/Source/Session/Session.swift
+++ b/Source/Session/Session.swift
@@ -214,6 +214,7 @@ extension Session: VisitDelegate {
 
 extension Session: VisitableDelegate {
     public func visitableViewWillAppear(_ visitable: Visitable) {
+        let lastDisappearingVisit = self.disappearingVisitForSnapshotting
         self.disappearingVisitForSnapshotting = nil
 
         guard let topmostVisit = self.topmostVisit, let currentVisit = self.currentVisit else { return }
@@ -228,7 +229,7 @@ extension Session: VisitableDelegate {
         } else if visitable === currentVisit.visitable && currentVisit.state == .started {
             // Navigating forward - complete navigation early
             completeNavigationForCurrentVisit()
-        } else if visitable !== topmostVisit.visitable {
+        } else if visitable !== topmostVisit.visitable || visitable === lastDisappearingVisit?.visitable {
             // Navigating backward
             visit(visitable, action: .restore)
         }

--- a/Source/Session/Session.swift
+++ b/Source/Session/Session.swift
@@ -35,6 +35,7 @@ public class Session: NSObject {
 
     private var currentVisit: Visit?
     private var topmostVisit: Visit?
+    private var disappearingVisitForSnapshotting: Visit?
 
     /// The topmost visitable is the visitable that has most recently completed a visit
     public var topmostVisitable: Visitable? {
@@ -213,6 +214,8 @@ extension Session: VisitDelegate {
 
 extension Session: VisitableDelegate {
     public func visitableViewWillAppear(_ visitable: Visitable) {
+        self.disappearingVisitForSnapshotting = nil
+
         guard let topmostVisit = self.topmostVisit, let currentVisit = self.currentVisit else { return }
 
         if visitable === topmostVisit.visitable && visitable.visitableViewController.isMovingToParent {
@@ -245,10 +248,11 @@ extension Session: VisitableDelegate {
     }
 
     public func visitableViewWillDisappear(_ visitable: Visitable) {
-        topmostVisit?.cacheSnapshot()
+        self.disappearingVisitForSnapshotting = topmostVisit
     }
 
     public func visitableViewDidDisappear(_ visitable: Visitable) {
+        disappearingVisitForSnapshotting?.cacheSnapshot()
         deactivateVisitable(visitable)
     }
 

--- a/Source/Session/Session.swift
+++ b/Source/Session/Session.swift
@@ -244,6 +244,14 @@ extension Session: VisitableDelegate {
         }
     }
 
+    public func visitableViewWillDisappear(_ visitable: Visitable) {
+        topmostVisit?.cacheSnapshot()
+    }
+
+    public func visitableViewDidDisappear(_ visitable: Visitable) {
+        deactivateVisitable(visitable)
+    }
+
     public func visitableDidRequestReload(_ visitable: Visitable) {
         guard visitable === topmostVisitable else { return }
         reload()

--- a/Source/Visit/Visit.swift
+++ b/Source/Visit/Visit.swift
@@ -68,6 +68,10 @@ class Visit: NSObject {
         delegate?.visitDidFinish(self)
     }
 
+    func cacheSnapshot() {
+        bridge.cacheSnapshot()
+    }
+
     func startVisit() {}
     func cancelVisit() {}
     func completeVisit() {}

--- a/Source/Visitable/Visitable.swift
+++ b/Source/Visitable/Visitable.swift
@@ -4,6 +4,8 @@ import WebKit
 public protocol VisitableDelegate: AnyObject {
     func visitableViewWillAppear(_ visitable: Visitable)
     func visitableViewDidAppear(_ visitable: Visitable)
+    func visitableViewWillDisappear(_ visitable: Visitable)
+    func visitableViewDidDisappear(_ visitable: Visitable)
     func visitableDidRequestReload(_ visitable: Visitable)
     func visitableDidRequestRefresh(_ visitable: Visitable)
 }

--- a/Source/Visitable/VisitableViewController.swift
+++ b/Source/Visitable/VisitableViewController.swift
@@ -28,6 +28,16 @@ open class VisitableViewController: UIViewController, Visitable {
         visitableDelegate?.visitableViewDidAppear(self)
     }
 
+    open override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        visitableDelegate?.visitableViewWillDisappear(self)
+    }
+
+    open override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        visitableDelegate?.visitableViewDidDisappear(self)
+    }
+
     // MARK: Visitable
 
     open func visitableDidRender() {

--- a/Source/WebView/WebViewBridge.swift
+++ b/Source/WebView/WebViewBridge.swift
@@ -76,6 +76,10 @@ final class WebViewBridge {
         callJavaScript(function: "window.turboNative.clearSnapshotCache")
     }
 
+    func cacheSnapshot() {
+        callJavaScript(function: "window.turboNative.cacheSnapshot")
+    }
+
     func cancelVisit(withIdentifier identifier: String) {
         callJavaScript(function: "window.turboNative.cancelVisitWithIdentifier", arguments: [identifier])
     }

--- a/Source/WebView/turbo.js
+++ b/Source/WebView/turbo.js
@@ -64,6 +64,12 @@
       }
     }
 
+    cacheSnapshot() {
+      if (window.Turbo) {
+        Turbo.session.view.cacheSnapshot()
+      }
+    }
+
     // Current visit
 
     issueRequestForVisitWithIdentifier(identifier) {


### PR DESCRIPTION
This PR fixes https://github.com/hotwired/turbo-ios/issues/180.

Today, when dismissing eg. a modal, a snapshot is _not_ taken of the WebView before the dismissal. This is different to the conceptual idea of snapshots in Turbo, where a snapshot it taken before any navigation events happen, so that any re-visits could show a snapshot.

This leads to some unexpected behavior, the most simple example being in the Demo app, where opening the modal example multiple times leads to no or stale snapshots being shown, as described in #180.

This PR addresses that by notifying adding two new lifecycle methods to the Session - `visitableViewWillDisappear` and `visitableViewDidDisappear`. When a `Visitable` will disappear (eg. if closing a modal or otherwise navigating away from it natively), a snapshot is taken of the page, ensuring that we have a fresh snapshot to show on next re-visit. When the `Visitable` did disappear, it's WebView will be deactivated, ensuring that there's no "orphaned", but active WebView.

In a normal single-session setup this should have no effect, but it fixes some of the issues we've seen while using a multi-session setup (eg. with tabs, modals, stacks etc.).

The behavior before in the demo app with a timeout on the `/new` page and showing a random number:

https://github.com/hotwired/turbo-ios/assets/195925/8eef43a6-1547-43aa-a2e9-6ddc39aeb9ad

The behavior with the changes in this PR:

https://github.com/hotwired/turbo-ios/assets/195925/c628dc77-7ba8-40af-af65-63c9a30eed73

CC @jayohms @joemasilotti 