### PR TITLE
Fix snapshot cache issue in Turbo Navigator

### DIFF
--- a/Source/Session/Session.swift
+++ b/Source/Session/Session.swift
@@ -14,6 +14,8 @@ public class Session: NSObject {
     private lazy var bridge = WebViewBridge(webView: webView)
     private var initialized = false
     private var refreshing = false
+    private var isShowingStaleContent = false
+    private var isSnapshotCacheStale = false
 
     /// Automatically creates a web view with the passed-in configuration
     public convenience init(webViewConfiguration: WKWebViewConfiguration? = nil) {
@@ -89,6 +91,18 @@ public class Session: NSObject {
     
     public func clearSnapshotCache() {
         bridge.clearSnapshotCache()
+    }
+
+    // MARK: Caching
+
+    /// Clear the snapshot cache the next time the visitable view appears.
+    public func markSnapshotCacheAsStale() {
+        isSnapshotCacheStale = true
+    }
+
+    /// Reload the `Session` the next time the visitable view appears.
+    public func markContentAsStale() {
+        isShowingStaleContent = true
     }
 
     // MARK: Visitable activation
@@ -228,6 +242,12 @@ extension Session: VisitableDelegate {
         } else if visitable !== topmostVisit.visitable {
             // Navigating backward
             visit(visitable, action: .restore)
+        } else if isShowingStaleContent {
+            reload()
+            isShowingStaleContent = false
+        } else if isSnapshotCacheStale {
+            clearSnapshotCache()
+            isSnapshotCacheStale = false
         }
     }
 

--- a/Source/Turbo Navigator/TurboNavigator.swift
+++ b/Source/Turbo Navigator/TurboNavigator.swift
@@ -143,7 +143,7 @@ extension TurboNavigator: SessionDelegate {
 
     public func sessionDidFinishFormSubmission(_ session: Session) {
         if session == modalSession {
-            self.session.clearSnapshotCache()
+            self.session.markSnapshotCacheAsStale()
         }
         if let url = session.topmostVisitable?.visitableURL {
             delegate.formSubmissionDidFinish(at: url)


### PR DESCRIPTION
This PR fixes the following issue where the snapshot cache doesn't get cleared.

### To recreate:

1. Present a modal that submits a form - this calls `clearSnapshotCache()
2. Navigate back

### Expected behavior:

The flash message appears on the redirected to page. Navigating back reloads the page from the server.

### Actual behavior:

The flash message is "eaten" by Rails because turbo-ios makes two requests to the show page. Navigating back shows the stale content because the snapshot cache was never cleared.

### PR behavior:

(same as expected)

### Notes:

This PR assumes that PR #184 is merged into turbo-ios (this PR cherry-picks that commit).