### PR TITLE
Stale content

### DIFF
--- a/Source/Session/Session.swift
+++ b/Source/Session/Session.swift
@@ -14,6 +14,7 @@ public class Session: NSObject {
     private lazy var bridge = WebViewBridge(webView: webView)
     private var initialized = false
     private var refreshing = false
+    private var needsReload = false
 
     /// Automatically creates a web view with the passed-in configuration
     public convenience init(webViewConfiguration: WKWebViewConfiguration? = nil) {
@@ -89,6 +90,10 @@ public class Session: NSObject {
     
     public func clearSnapshotCache() {
         bridge.clearSnapshotCache()
+    }
+
+    public func setNeedsReload() {
+        needsReload = true
     }
 
     // MARK: Visitable activation
@@ -228,6 +233,9 @@ extension Session: VisitableDelegate {
         } else if visitable !== topmostVisit.visitable {
             // Navigating backward
             visit(visitable, action: .restore)
+        } else if needsReload {
+            reload()
+            needsReload = false
         }
     }
 

--- a/Source/Session/Session.swift
+++ b/Source/Session/Session.swift
@@ -14,7 +14,8 @@ public class Session: NSObject {
     private lazy var bridge = WebViewBridge(webView: webView)
     private var initialized = false
     private var refreshing = false
-    private var needsReload = false
+    private var isShowingStaleContent = false
+    private var isSnapshotCacheStale = false
 
     /// Automatically creates a web view with the passed-in configuration
     public convenience init(webViewConfiguration: WKWebViewConfiguration? = nil) {
@@ -92,8 +93,16 @@ public class Session: NSObject {
         bridge.clearSnapshotCache()
     }
 
-    public func setNeedsReload() {
-        needsReload = true
+    // MARK: Caching
+
+    /// Clear the snapshot cache the next time the visitable view appears.
+    public func markSnapshotCacheAsStale() {
+        isSnapshotCacheStale = true
+    }
+
+    /// Reload the `Session` the next time the visitable view appears.
+    public func markContentAsStale() {
+        isShowingStaleContent = true
     }
 
     // MARK: Visitable activation
@@ -233,9 +242,12 @@ extension Session: VisitableDelegate {
         } else if visitable !== topmostVisit.visitable {
             // Navigating backward
             visit(visitable, action: .restore)
-        } else if needsReload {
+        } else if isShowingStaleContent {
             reload()
-            needsReload = false
+            isShowingStaleContent = false
+        } else if isSnapshotCacheStale {
+            clearSnapshotCache()
+            isSnapshotCacheStale = false
         }
     }
 


### PR DESCRIPTION
This PR exposes two ways of clearing stale content in turbo-ios:

1. `markSnapshotCacheAsStale()`
2. `markContentAsStale()`

Due to a race condition discovered in #173, clearing the snapshot cache must occur when the visitable view appears. This prevents developers from calling `clearSnapshotCache()` directly from `sessionDidFinishFormSubmission(_:)`: #183.