### PR TITLE
Reload or recreate web view when its process is terminated

### DIFF
--- a/Demo/SceneController.swift
+++ b/Demo/SceneController.swift
@@ -64,6 +64,14 @@ extension SceneController: UIWindowSceneDelegate {
 
         navigator.route(rootURL)
     }
+    
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        navigator.appDidBecomeActive()
+    }
+    
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        navigator.appDidEnterBackground()
+    }
 }
 
 extension SceneController: TurboNavigatorDelegate {

--- a/Source/Turbo Navigator/Extensions/WKWebView+ebContentProcess.swift
+++ b/Source/Turbo Navigator/Extensions/WKWebView+ebContentProcess.swift
@@ -1,0 +1,28 @@
+import Foundation
+import WebKit
+
+enum WebContentProcessState {
+    case active
+    case terminated
+}
+
+extension WKWebView {
+    /// Queries the state of the web content process asynchronously.
+    ///
+    /// This method evaluates a simple JavaScript function in the web view to determine if the web content process is active.
+    ///
+    /// - Parameter completionHandler: A closure to be called when the query completes. The closure takes a single argument representing the state of the web content process.
+    ///
+    /// - Note: The web content process is considered active if the JavaScript evaluation succeeds without error. 
+    /// If an error occurs during evaluation, the process is considered terminated.
+    func queryWebContentProcessState(completionHandler: @escaping (WebContentProcessState) -> Void) {
+        evaluateJavaScript("(function() { return '1'; })();") { _, error in
+            if let _ = error {
+                completionHandler(.terminated)
+                return
+            }
+            
+            completionHandler(.active)
+        }
+    }
+}


### PR DESCRIPTION
This PR improves handling of the terminated web view processes which leave the web views with a white screen.

@zoejessica did a thorough investigation on this topic. The following is taken from one of our PRs at 37signals.

> You can read more [here](https://nevermeant.dev/handling-blank-wkwebviews/#killed-before-being-rendered), but tl;dr we suspect that there are three ways web views can become blank, either:
> 
> 1. they are killed in the "normal" way in the background through memory pressure, the delegate method fires, and they can then be reloaded, or
> 2. they are killed by the system without triggering a delegate callback, but can be recovered with a reload, or
> 3. they are killed by the system in a way that leaves them non-recoverable with a reload.

This PR takes care of all three cases.