### PR TITLE
Custom navigation controller

### DIFF
--- a/Source/Turbo Navigator/TurboNavigationHierarchyController.swift
+++ b/Source/Turbo Navigator/TurboNavigationHierarchyController.swift
@@ -25,11 +25,11 @@ class TurboNavigationHierarchyController {
 
     init(
         delegate: TurboNavigationHierarchyControllerDelegate,
-        navigationControler: UINavigationController = Turbo.config.defaultNavigationController(),
+        navigationController: UINavigationController = Turbo.config.defaultNavigationController(),
         modalNavigationController: UINavigationController = Turbo.config.defaultNavigationController()
     ) {
         self.delegate = delegate
-        self.navigationController = navigationControler
+        self.navigationController = navigationController
         self.modalNavigationController = modalNavigationController
     }
 

--- a/Source/Turbo Navigator/TurboNavigationHierarchyController.swift
+++ b/Source/Turbo Navigator/TurboNavigationHierarchyController.swift
@@ -23,7 +23,11 @@ class TurboNavigationHierarchyController {
         }
     }
 
-    init(delegate: TurboNavigationHierarchyControllerDelegate, navigationControler: UINavigationController = UINavigationController(), modalNavigationController: UINavigationController = UINavigationController()) {
+    init(
+        delegate: TurboNavigationHierarchyControllerDelegate,
+        navigationControler: UINavigationController = Turbo.config.defaultNavigationController(),
+        modalNavigationController: UINavigationController = Turbo.config.defaultNavigationController()
+    ) {
         self.delegate = delegate
         self.navigationController = navigationControler
         self.modalNavigationController = modalNavigationController

--- a/Source/Turbo.swift
+++ b/Source/Turbo.swift
@@ -17,6 +17,12 @@ public class TurboConfig {
         VisitableViewController(url: url)
     }
 
+    /// The navigation controller used in `TurboNavigator` for the main and modal stacks.
+    /// Must be a `UINavigationController` or subclass.
+    public var defaultNavigationController: () -> UINavigationController = {
+        UINavigationController()
+    }
+
     /// Optionally customize the web views used by each Turbo Session.
     /// Ensure you return a new instance each time.
     public var makeCustomWebView: WebViewBlock = { (configuration: WKWebViewConfiguration) in

--- a/Tests/Turbo Navigator/TurboNavigatorTests.swift
+++ b/Tests/Turbo Navigator/TurboNavigatorTests.swift
@@ -11,7 +11,7 @@ final class TurboNavigationHierarchyControllerTests: XCTestCase {
         modalNavigationController = TestableNavigationController()
 
         navigator = TurboNavigator(session: session, modalSession: modalSession)
-        hierarchyController = TurboNavigationHierarchyController(delegate: navigator, navigationControler: navigationController, modalNavigationController: modalNavigationController)
+        hierarchyController = TurboNavigationHierarchyController(delegate: navigator, navigationController: navigationController, modalNavigationController: modalNavigationController)
         navigator.hierarchyController = hierarchyController
 
         loadNavigationControllerInWindow()


### PR DESCRIPTION
This PR provides support to customize the `UINavigationController` used in Turbo Navigator.

This functionality was originally removed when we introduced `TurboNavigationHierarchyController` as it is internal to the library.

For context, I need a way to hide the status bar on certain screens. Normally, this would work:

```swift
class TurboWebViewController: VisitableViewController {
    override var prefersStatusBarHidden: Bool { true }

    // ...
}
```

But when presented in a `UINavigationController` this is ignored. The following change needs to be made to the parent navigation controller to defer this setting to the top view controller:

```swift
class NavigationController: UINavigationController {
    override var childForStatusBarHidden: UIViewController? { topViewController }
}
```

This PR allows me to configure the default navigation controllers, like so:

```swift
Turbo.config.defaultNavigationController = { NavigationController() }
```