### PR TITLE
Alert for iPad instead of an ActionSheet

### DIFF
--- a/Demo/Strada/MenuComponent.swift
+++ b/Demo/Strada/MenuComponent.swift
@@ -6,47 +6,47 @@ import UIKit
 /// which will send the selected index of the tapped menu item back to the web.
 final class MenuComponent: BridgeComponent {
     override class var name: String { "menu" }
-    
+
     override func onReceive(message: Message) {
         guard let event = Event(rawValue: message.event) else {
             return
         }
-        
+
         switch event {
         case .display:
             handleDisplayEvent(message: message)
         }
     }
-    
+
     // MARK: Private
-    
+
     private var viewController: UIViewController? {
         delegate.destination as? UIViewController
     }
-    
+
     private func handleDisplayEvent(message: Message) {
         guard let data: MessageData = message.data() else { return }
         showAlertSheet(with: data.title, items: data.items)
     }
-    
+
     private func showAlertSheet(with title: String, items: [Item]) {
         let alertController = UIAlertController(title: title,
                                                 message: nil,
-                                                preferredStyle: .actionSheet)
-        
+                                                preferredStyle: UIDevice.current.userInterfaceIdiom == .pad ? .alert : .actionSheet)
+
         for item in items {
             let action = UIAlertAction(title: item.title, style: .default) {[weak self] _ in
                 self?.onItemSelected(item: item)
             }
             alertController.addAction(action)
         }
-        
+
         let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
         alertController.addAction(cancelAction)
-        
+
         viewController?.present(alertController, animated: true)
     }
-    
+
     private func onItemSelected(item: Item) {
         reply(to: Event.display.rawValue,
               with: SelectionMessageData(selectedIndex: item.index))
@@ -68,12 +68,12 @@ private extension MenuComponent {
         let title: String
         let items: [Item]
     }
-    
+
     struct Item: Decodable {
         let title: String
         let index: Int
     }
-    
+
     struct SelectionMessageData: Encodable {
         let selectedIndex:Int
     }


### PR DESCRIPTION
There's an issue in the MenuComponent Demo on iPads. When clicking on menu icons, the app crashes with the following error:

```
Terminating app due to uncaught exception 'NSGenericException', reason: 'Your application has presented a UIAlertController (<UIAlertController: 0x106808800>) of style UIAlertControllerStyleActionSheet from UINavigationController (<UINavigationController: 0x10780aa00>). The modalPresentationStyle of a UIAlertController with this style is UIModalPresentationPopover. You must provide location information for this popover through the alert controller's popoverPresentationController. You must provide either a sourceView and sourceRect or a barButtonItem.  If this information is not known when you present the alert controller, you may provide it in the UIPopoverPresentationControllerDelegate method -prepareForPopoverPresentation.
```

We need to specify the position. I'm not sure how to implement it, so I simply changed actionSheet to alert for iPads.