### PR TITLE
Hide retry button in ErrorView if no handler is given

### DIFF
--- a/Demo/SceneController.swift
+++ b/Demo/SceneController.swift
@@ -90,11 +90,11 @@ extension SceneController: TurboNavigatorDelegate {
         }
     }
 
-    func visitableDidFailRequest(_ visitable: Visitable, error: Error, retry: @escaping RetryBlock) {
+    func visitableDidFailRequest(_ visitable: Visitable, error: Error, retryHandler: RetryBlock?) {
         if let turboError = error as? TurboError, case let .http(statusCode) = turboError, statusCode == 401 {
             promptForAuthentication()
         } else if let errorPresenter = visitable as? ErrorPresenter {
-            errorPresenter.presentError(error, handler: retry)
+            errorPresenter.presentError(error, retryHandler: retryHandler)
         } else {
             let alert = UIAlertController(title: "Visit failed!", message: error.localizedDescription, preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))

--- a/Source/Turbo Navigator/Helpers/ErrorPresenter.swift
+++ b/Source/Turbo Navigator/Helpers/ErrorPresenter.swift
@@ -16,8 +16,7 @@ public extension ErrorPresenter {
     ///   - error: presents the data in this error
     ///   - retryHandler: a user-triggered action to perform in case the error is recoverable
     func presentError(_ error: Error, retryHandler: Handler?) {
-        let errorView = ErrorView(error: error,
-                                  shouldShowRetryButton: (retryHandler != nil)) { [unowned self] in
+        let errorView = ErrorView(error: error, shouldShowRetryButton: (retryHandler != nil)) {
             retryHandler?()
             self.removeErrorViewController()
         }

--- a/Source/Turbo Navigator/Helpers/ErrorPresenter.swift
+++ b/Source/Turbo Navigator/Helpers/ErrorPresenter.swift
@@ -13,8 +13,8 @@ public extension ErrorPresenter {
     /// Tapping `Retry` will call `retryHandler?()` then dismiss the error.
     ///
     /// - Parameters:
-    ///   - error: <#error description#>
-    ///   - retryHandler: <#retryHandler description#>
+    ///   - error: presents the data in this error
+    ///   - retryHandler: a user-triggered action to perform in case the error is recoverable
     func presentError(_ error: Error, retryHandler: Handler?) {
         let errorView = ErrorView(error: error,
                                   shouldShowRetryButton: (retryHandler != nil)) { [unowned self] in

--- a/Source/Turbo Navigator/Helpers/ErrorPresenter.swift
+++ b/Source/Turbo Navigator/Helpers/ErrorPresenter.swift
@@ -3,14 +3,22 @@ import SwiftUI
 public protocol ErrorPresenter: UIViewController {
     typealias Handler = () -> Void
 
-    func presentError(_ error: Error, handler: Handler?)
+    func presentError(_ error: Error, retryHandler: Handler?)
 }
 
 public extension ErrorPresenter {
-    func presentError(_ error: Error, handler: Handler?) {
+    
+    /// Presents an error in a full screen view.
+    /// The error view will display a `Retry` button if `retryHandler != nil`.
+    /// Tapping `Retry` will call `retryHandler?()` then dismiss the error.
+    ///
+    /// - Parameters:
+    ///   - error: <#error description#>
+    ///   - retryHandler: <#retryHandler description#>
+    func presentError(_ error: Error, retryHandler: Handler?) {
         let errorView = ErrorView(error: error,
-                                  shouldShowRetryButton: (handler != nil)) { [unowned self] in
-            handler?()
+                                  shouldShowRetryButton: (retryHandler != nil)) { [unowned self] in
+            retryHandler?()
             self.removeErrorViewController()
         }
 

--- a/Source/Turbo Navigator/Helpers/ErrorPresenter.swift
+++ b/Source/Turbo Navigator/Helpers/ErrorPresenter.swift
@@ -3,13 +3,14 @@ import SwiftUI
 public protocol ErrorPresenter: UIViewController {
     typealias Handler = () -> Void
 
-    func presentError(_ error: Error, handler: @escaping Handler)
+    func presentError(_ error: Error, handler: Handler?)
 }
 
 public extension ErrorPresenter {
-    func presentError(_ error: Error, handler: @escaping () -> Void) {
-        let errorView = ErrorView(error: error) { [unowned self] in
-            handler()
+    func presentError(_ error: Error, handler: Handler?) {
+        let errorView = ErrorView(error: error,
+                                  shouldShowRetryButton: (handler != nil)) { [unowned self] in
+            handler?()
             self.removeErrorViewController()
         }
 
@@ -34,6 +35,7 @@ extension UIViewController: ErrorPresenter {}
 
 private struct ErrorView: View {
     let error: Error
+    let shouldShowRetryButton: Bool
     let handler: ErrorPresenter.Handler?
 
     var body: some View {
@@ -49,10 +51,12 @@ private struct ErrorView: View {
                 .font(.body)
                 .multilineTextAlignment(.center)
 
-            Button("Retry") {
-                handler?()
+            if shouldShowRetryButton {
+                Button("Retry") {
+                    handler?()
+                }
+                .font(.system(size: 17, weight: .bold))
             }
-            .font(.system(size: 17, weight: .bold))
         }
         .padding(32)
     }
@@ -64,7 +68,7 @@ private struct ErrorView_Previews: PreviewProvider {
             domain: "com.example.error",
             code: 1001,
             userInfo: [NSLocalizedDescriptionKey: "Could not connect to the server."]
-        )) {}
+        ), shouldShowRetryButton: true) {}
     }
 }
 

--- a/Source/Turbo Navigator/TurboNavigatorDelegate.swift
+++ b/Source/Turbo Navigator/TurboNavigatorDelegate.swift
@@ -20,7 +20,7 @@ public protocol TurboNavigatorDelegate: AnyObject {
     /// An error occurred loading the request, present it to the user.
     /// Retry the request by executing the closure.
     /// - Important: If not implemented, will present the error's localized description and a Retry button.
-    func visitableDidFailRequest(_ visitable: Visitable, error: Error, retry: RetryBlock?)
+    func visitableDidFailRequest(_ visitable: Visitable, error: Error, retryHandler: RetryBlock?)
 
     /// Respond to authentication challenge presented by web servers behing basic auth.
     /// If not implemented, default handling will be performed.
@@ -44,9 +44,9 @@ public extension TurboNavigatorDelegate {
         .openViaSafariController
     }
 
-    func visitableDidFailRequest(_ visitable: Visitable, error: Error, retry: RetryBlock?) {
+    func visitableDidFailRequest(_ visitable: Visitable, error: Error, retryHandler: RetryBlock?) {
         if let errorPresenter = visitable as? ErrorPresenter {
-            errorPresenter.presentError(error, retryHandler: retry)
+            errorPresenter.presentError(error, retryHandler: retryHandler)
         }
     }
 

--- a/Source/Turbo Navigator/TurboNavigatorDelegate.swift
+++ b/Source/Turbo Navigator/TurboNavigatorDelegate.swift
@@ -46,7 +46,7 @@ public extension TurboNavigatorDelegate {
 
     func visitableDidFailRequest(_ visitable: Visitable, error: Error, retry: RetryBlock?) {
         if let errorPresenter = visitable as? ErrorPresenter {
-            errorPresenter.presentError(error, handler: retry)
+            errorPresenter.presentError(error, retryHandler: retry)
         }
     }
 

--- a/Source/Turbo Navigator/TurboNavigatorDelegate.swift
+++ b/Source/Turbo Navigator/TurboNavigatorDelegate.swift
@@ -20,7 +20,7 @@ public protocol TurboNavigatorDelegate: AnyObject {
     /// An error occurred loading the request, present it to the user.
     /// Retry the request by executing the closure.
     /// - Important: If not implemented, will present the error's localized description and a Retry button.
-    func visitableDidFailRequest(_ visitable: Visitable, error: Error, retry: @escaping RetryBlock)
+    func visitableDidFailRequest(_ visitable: Visitable, error: Error, retry: RetryBlock?)
 
     /// Respond to authentication challenge presented by web servers behing basic auth.
     /// If not implemented, default handling will be performed.
@@ -44,7 +44,7 @@ public extension TurboNavigatorDelegate {
         .openViaSafariController
     }
 
-    func visitableDidFailRequest(_ visitable: Visitable, error: Error, retry: @escaping RetryBlock) {
+    func visitableDidFailRequest(_ visitable: Visitable, error: Error, retry: RetryBlock?) {
         if let errorPresenter = visitable as? ErrorPresenter {
             errorPresenter.presentError(error, handler: retry)
         }


### PR DESCRIPTION
In some instances, it's not desirable for the visitable view controller to present a Retry button when the visit fails. This PR allows a `nil` handler to be passed to `ErrorView`. This will hide the retry button.