### PR TITLE
Detect cross-origin visit request attempts

### DIFF
--- a/Source/Session/Session.swift
+++ b/Source/Session/Session.swift
@@ -311,7 +311,10 @@ extension Session: WebViewDelegate {
     }
     
     func webView(_ bridge: WebViewBridge, didProposeVisitToCrossOriginRedirect location: URL) {
-        // TODO
+        // Remove the current visitable from the backstack since it
+        // resulted in a visit failure due to a cross-origin redirect.
+        activatedVisitable?.visitableViewController.navigationController?.popViewController(animated: false)
+        openExternalURL(location)
     }
     
     func webView(_ webView: WebViewBridge, didStartFormSubmissionToLocation location: URL) {

--- a/Source/Session/Session.swift
+++ b/Source/Session/Session.swift
@@ -310,6 +310,10 @@ extension Session: WebViewDelegate {
         delegate?.session(self, didProposeVisit: proposal)
     }
     
+    func webView(_ bridge: WebViewBridge, didProposeVisitToCrossOriginRedirect location: URL) {
+        // TODO
+    }
+    
     func webView(_ webView: WebViewBridge, didStartFormSubmissionToLocation location: URL) {
         delegate?.sessionDidStartFormSubmission(self)
     }

--- a/Source/WebView/ScriptMessage.swift
+++ b/Source/WebView/ScriptMessage.swift
@@ -52,6 +52,7 @@ extension ScriptMessage {
         case pageLoadFailed
         case errorRaised
         case visitProposed
+        case visitProposedToCrossOriginRedirect
         case visitProposalScrollingToAnchor
         case visitProposalRefreshingPage
         case visitStarted

--- a/Source/WebView/WebViewBridge.swift
+++ b/Source/WebView/WebViewBridge.swift
@@ -2,6 +2,7 @@ import WebKit
 
 protocol WebViewDelegate: AnyObject {
     func webView(_ webView: WebViewBridge, didProposeVisitToLocation location: URL, options: VisitOptions)
+    func webView(_ webView: WebViewBridge, didProposeVisitToCrossOriginRedirect location: URL)
     func webViewDidInvalidatePage(_ webView: WebViewBridge)
     func webView(_ webView: WebViewBridge, didStartFormSubmissionToLocation location: URL)
     func webView(_ webView: WebViewBridge, didFinishFormSubmissionToLocation location: URL)
@@ -129,6 +130,8 @@ extension WebViewBridge: ScriptMessageHandlerDelegate {
             delegate?.webViewDidInvalidatePage(self)
         case .visitProposed:
             delegate?.webView(self, didProposeVisitToLocation: message.location!, options: message.options!)
+        case .visitProposedToCrossOriginRedirect:
+            delegate?.webView(self, didProposeVisitToCrossOriginRedirect: message.location!)
         case .visitProposalScrollingToAnchor:
             break
         case .visitProposalRefreshingPage:


### PR DESCRIPTION
This is the corresponding PR to the same `turbo-android` issue outlined in https://github.com/hotwired/turbo-android/pull/325

The core `turbo.js` library does not permit cross-origin visit requests (i.e. a link that redirects to an external domain). These requests call the adapter method `visitRequestFailedWithStatusCode(visit, statusCode)` for all platforms.

To handle this in the [browser adapter](https://github.com/hotwired/turbo/blob/main/src/core/native/browser_adapter.js#L41-L55), non-HTTP status code failures update the `window.location` so the browser can handle the top-level redirect. The browser adapter does not actually know whether a cross-origin redirect was attempted, since the CORS policy restricts requests to the `same-origin`, but updating the `window.location` directly bypasses needing this knowledge.

The mobile adapters, however, can't just update the `window.location` — a new visit needs to be proposed so the native app can decide how to handle the external url request. This PR finds any potential cross-origin redirect locations when a visit request fails with a non-HTTP status code and proposes the external redirect location as a new visit.

Fixes #200 

Test with the demo branch: https://github.com/hotwired/turbo-native-demo/pull/34