### PR TITLE
Do not explicitly set the constraints for refreshControl

### DIFF
--- a/Source/Visitable/VisitableView.swift
+++ b/Source/Visitable/VisitableView.swift
@@ -69,16 +69,6 @@ open class VisitableView: UIView {
         
         #if !targetEnvironment(macCatalyst)
         scrollView.addSubview(refreshControl)
-
-        /// Infer refresh control's default height from its frame, if given.
-        /// Otherwise fallback to 60 (the default height).
-        let refreshControlHeight = refreshControl.frame.height > 0 ? refreshControl.frame.height : 60
-        
-        NSLayoutConstraint.activate([
-            refreshControl.centerXAnchor.constraint(equalTo: centerXAnchor),
-            refreshControl.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
-            refreshControl.heightAnchor.constraint(equalToConstant: refreshControlHeight)
-        ])
         #endif
     }
 


### PR DESCRIPTION
Today, the refresh control is installed with layout constraints explicitly set. The explicitly set layout constraints has no visible effect vs. just not setting them, _but_ setting them does cause imcompatibility with any custom `consetInsets` of the scroll view.

If for example a `VisitableView` is shown in an app with a translucent navigation bar, the refresh control will - with explicit layout constraints - be positioned _under_ the tranlucent navigation bar, even if the scroll view has it's `contentInset` configured to correspond to the navigation bar height.

Since the `installRefreshControl` method is marked as private, it's not possible to easily skip adding the layout constraints today to make the refresh control compatible with custom content insets.

This PR removes the explicit layout constraints.

In the demo app, there's no visible difference between setting them explicitly and not setting them and the existing behavior. This is a video of the demo app with this PR applied:

https://github.com/hotwired/turbo-ios/assets/195925/1f73da10-f788-4130-abb6-f64aa08ef544



