### PR TITLE
Add cross-origin redirect delegate

### DIFF
--- a/Docs/Overview.md
+++ b/Docs/Overview.md
@@ -104,6 +104,15 @@ The default `Action` is `.advance`. In most cases you’ll respond to an advance
 
 When you follow a link annotated with `data-turbo-action="replace"`, the proposed Action will be `.replace`. Usually you’ll want to handle a replace visit by replacing the top-most visible view controller with a new one instead of pushing.
 
+### Responding to cross-origin redirects
+
+When a Visit action results in a cross-origin redirect that Turbo iOS is not able to handle due to the cross-origin nature, your Session's delegate can handle this by implementing the `session:didProposeVisitToCrossOriginRedirect`. Depending on your navigation structure, you could choose to pop the view controller and open the URL in a an external browser, for example:
+
+```swift
+navigationController.popViewController(animated: false)
+UIApplication.shared.open(url)
+```
+
 ## Handling Failed Requests
 
 Turbo iOS calls the `session:didFailRequestForVisitable:error:` method when a visit request fails. This might be because of a network error, or because the server returned an HTTP 4xx or 5xx status code. If it was a network error in the main cold boot visit, it will be the `NSError` returned by WebKit. If it was a HTTP error or a network error from a JavaScript visit the error will be a `TurboError` and you can retrieve the status code.

--- a/Source/Session/Session.swift
+++ b/Source/Session/Session.swift
@@ -311,10 +311,7 @@ extension Session: WebViewDelegate {
     }
     
     func webView(_ bridge: WebViewBridge, didProposeVisitToCrossOriginRedirect location: URL) {
-        // Remove the current visitable from the backstack since it
-        // resulted in a visit failure due to a cross-origin redirect.
-        activatedVisitable?.visitableViewController.navigationController?.popViewController(animated: false)
-        openExternalURL(location)
+        delegate?.session(self, didProposeVisitToCrossOriginRedirect: location)
     }
     
     func webView(_ webView: WebViewBridge, didStartFormSubmissionToLocation location: URL) {

--- a/Source/Session/Session.swift
+++ b/Source/Session/Session.swift
@@ -311,7 +311,10 @@ extension Session: WebViewDelegate {
     }
     
     func webView(_ bridge: WebViewBridge, didProposeVisitToCrossOriginRedirect location: URL) {
-        // TODO
+        // Remove the current visitable from the backstack since it
+        // resulted in a visit failure due to a cross-origin redirect.
+        activatedVisitable?.visitableViewController.navigationController?.popViewController(animated: false)
+        openExternalURL(location)
     }
     
     func webView(_ webView: WebViewBridge, didStartFormSubmissionToLocation location: URL) {

--- a/Source/Session/Session.swift
+++ b/Source/Session/Session.swift
@@ -310,6 +310,10 @@ extension Session: WebViewDelegate {
         delegate?.session(self, didProposeVisit: proposal)
     }
     
+    func webView(_ bridge: WebViewBridge, didProposeVisitToCrossOriginRedirect location: URL) {
+        // TODO
+    }
+    
     func webView(_ webView: WebViewBridge, didStartFormSubmissionToLocation location: URL) {
         delegate?.sessionDidStartFormSubmission(self)
     }

--- a/Source/Session/SessionDelegate.swift
+++ b/Source/Session/SessionDelegate.swift
@@ -2,6 +2,7 @@ import UIKit
 
 public protocol SessionDelegate: AnyObject {
     func session(_ session: Session, didProposeVisit proposal: VisitProposal)
+    func session(_ session: Session, didProposeVisitToCrossOriginRedirect url: URL)
     func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error)
     
     func session(_ session: Session, openExternalURL url: URL)
@@ -24,6 +25,8 @@ public extension SessionDelegate {
     func session(_ session: Session, openExternalURL url: URL) {
         UIApplication.shared.open(url)
     }
+
+    func session(_ session: Session, didProposeVisitToCrossOriginRedirect url: URL) {}
     
     func sessionDidStartRequest(_ session: Session) {}
     func sessionDidFinishRequest(_ session: Session) {}

--- a/Source/WebView/ScriptMessage.swift
+++ b/Source/WebView/ScriptMessage.swift
@@ -52,6 +52,7 @@ extension ScriptMessage {
         case pageLoadFailed
         case errorRaised
         case visitProposed
+        case visitProposedToCrossOriginRedirect
         case visitProposalScrollingToAnchor
         case visitProposalRefreshingPage
         case visitStarted

--- a/Source/WebView/WebViewBridge.swift
+++ b/Source/WebView/WebViewBridge.swift
@@ -2,6 +2,7 @@ import WebKit
 
 protocol WebViewDelegate: AnyObject {
     func webView(_ webView: WebViewBridge, didProposeVisitToLocation location: URL, options: VisitOptions)
+    func webView(_ webView: WebViewBridge, didProposeVisitToCrossOriginRedirect location: URL)
     func webViewDidInvalidatePage(_ webView: WebViewBridge)
     func webView(_ webView: WebViewBridge, didStartFormSubmissionToLocation location: URL)
     func webView(_ webView: WebViewBridge, didFinishFormSubmissionToLocation location: URL)
@@ -129,6 +130,8 @@ extension WebViewBridge: ScriptMessageHandlerDelegate {
             delegate?.webViewDidInvalidatePage(self)
         case .visitProposed:
             delegate?.webView(self, didProposeVisitToLocation: message.location!, options: message.options!)
+        case .visitProposedToCrossOriginRedirect:
+            delegate?.webView(self, didProposeVisitToCrossOriginRedirect: message.location!)
         case .visitProposalScrollingToAnchor:
             break
         case .visitProposalRefreshingPage:


### PR DESCRIPTION
Follow-up of #201.

As discussed in #201 it would be preferrable to handle cross-origin redirects in the `SessionDelegate`.

This PR takes a stab at that to get the ball rolling so we can get feature parity between iOS and Android libs again :-)