### PR TITLE
Allow a nav controller to be pushed into a modal stack

### DIFF
--- a/Source/Turbo Navigator/TurboNavigationHierarchyController.swift
+++ b/Source/Turbo Navigator/TurboNavigationHierarchyController.swift
@@ -86,7 +86,10 @@ class TurboNavigationHierarchyController {
                 delegate.visit(visitable, on: .main, with: proposal.options)
             }
         case .modal:
-            if navigationController.presentedViewController != nil, !modalNavigationController.isBeingDismissed {
+            if let proposedModalNavController = controller as? UINavigationController {
+                proposedModalNavController.setModalPresentationStyle(via: proposal)
+                navigationController.present(proposedModalNavController, animated: true)
+            } else if navigationController.presentedViewController != nil, !modalNavigationController.isBeingDismissed {
                 pushOrReplace(on: modalNavigationController, with: controller, via: proposal)
             } else {
                 modalNavigationController.setViewControllers([controller], animated: true)
@@ -151,7 +154,10 @@ class TurboNavigationHierarchyController {
                 delegate.visit(visitable, on: .main, with: proposal.options)
             }
         case .modal:
-            if navigationController.presentedViewController != nil {
+            if let proposedModalNavController = controller as? UINavigationController {
+                proposedModalNavController.setModalPresentationStyle(via: proposal)
+                navigationController.present(proposedModalNavController, animated: true)
+            } else if navigationController.presentedViewController != nil {
                 modalNavigationController.replaceLastViewController(with: controller)
             } else {
                 modalNavigationController.setViewControllers([controller], animated: false)

--- a/Tests/Turbo Navigator/TurboNavigatorNavControllerTests.swift
+++ b/Tests/Turbo Navigator/TurboNavigatorNavControllerTests.swift
@@ -29,6 +29,20 @@ final class TurboNavigationHierarchyNavControllerTests: XCTestCase {
         XCTAssertEqual(navigationController.viewControllers.count, 1)
         XCTAssertEqual(modalNavigationController.viewControllers.count, 0)
         XCTAssertNotIdentical(navigationController.presentedViewController, modalNavigationController)
+        XCTAssertNotNil(navigationController.presentedViewController as? UINavigationController)
+    }
+    
+    func test_default_modal_replace_presentsModal() {
+        navigationController.pushViewController(UIViewController(), animated: false)
+        XCTAssertEqual(navigationController.viewControllers.count, 1)
+
+        let proposal = VisitProposal(path: "/navigation_controller", context: .modal, presentation: .replace)
+        navigator.route(proposal)
+
+        XCTAssertEqual(navigationController.viewControllers.count, 1)
+        XCTAssertEqual(modalNavigationController.viewControllers.count, 0)
+        XCTAssertNotIdentical(navigationController.presentedViewController, modalNavigationController)
+        XCTAssertNotNil(navigationController.presentedViewController as? UINavigationController)
     }
     
     // MARK: Private

--- a/Tests/Turbo Navigator/TurboNavigatorNavControllerTests.swift
+++ b/Tests/Turbo Navigator/TurboNavigatorNavControllerTests.swift
@@ -1,0 +1,82 @@
+import SafariServices
+@testable import Turbo
+import XCTest
+
+/// Tests are written in the following format:
+/// `test_currentContext_givenContext_givenPresentation_modifiers_result()`
+/// See the README for a more visually pleasing table.
+final class TurboNavigationHierarchyNavControllerTests: XCTestCase {
+    
+    override func setUp() {
+        navigationController = TestableNavigationController()
+        modalNavigationController = TestableNavigationController()
+
+        navigator = TurboNavigator(session: session, modalSession: modalSession)
+        navigator.delegate = mockDelegate
+        hierarchyController = TurboNavigationHierarchyController(delegate: navigator, navigationController: navigationController, modalNavigationController: modalNavigationController)
+        navigator.hierarchyController = hierarchyController
+
+        loadNavigationControllerInWindow()
+    }
+    
+    func test_default_modal_default_presentsNavigationControllerModal() {
+        navigationController.pushViewController(UIViewController(), animated: false)
+        XCTAssertEqual(navigationController.viewControllers.count, 1)
+        
+        let proposal = VisitProposal(path: "/navigation_controller", context: .modal)
+        navigator.route(proposal)
+        
+        XCTAssertEqual(navigationController.viewControllers.count, 1)
+        XCTAssertEqual(modalNavigationController.viewControllers.count, 0)
+        XCTAssertNotIdentical(navigationController.presentedViewController, modalNavigationController)
+    }
+    
+    // MARK: Private
+
+    private enum Context {
+        case main, modal
+    }
+
+    private let baseURL = URL(string: "https://example.com")!
+    private lazy var oneURL = baseURL.appendingPathComponent("/one")
+    private lazy var twoURL = baseURL.appendingPathComponent("/two")
+
+    private let session = Session(webView: Turbo.config.makeWebView())
+    private let modalSession = Session(webView: Turbo.config.makeWebView())
+
+    private var navigator: TurboNavigator!
+    private var mockDelegate = MockNavigatorDelegate()
+    private var hierarchyController: TurboNavigationHierarchyController!
+    private var navigationController: TestableNavigationController!
+    private var modalNavigationController: TestableNavigationController!
+
+    private let window = UIWindow()
+
+    // Simulate a "real" app so presenting view controllers works under test.
+    private func loadNavigationControllerInWindow() {
+        window.rootViewController = navigationController
+        window.makeKeyAndVisible()
+        navigationController.loadViewIfNeeded()
+    }
+
+    private func assertVisited(url: URL, on context: Context) {
+        switch context {
+        case .main:
+            XCTAssertEqual(navigator.session.activeVisitable?.visitableURL, url)
+        case .modal:
+            XCTAssertEqual(navigator.modalSession.activeVisitable?.visitableURL, url)
+        }
+    }
+}
+
+// MARK: - DElegate
+private class MockNavigatorDelegate: TurboNavigatorDelegate {
+    func handle(proposal: VisitProposal) -> ProposalResult {
+        if proposal.url.path == "/navigation_controller" {
+            let navController = UINavigationController(rootViewController: UIViewController())
+            return .acceptCustom(navController)
+        }
+        
+        return .accept
+    }
+}

--- a/Tests/Turbo Navigator/TurboNavigatorTests.swift
+++ b/Tests/Turbo Navigator/TurboNavigatorTests.swift
@@ -303,7 +303,7 @@ private class EmptyNavigationDelegate: TurboNavigationHierarchyControllerDelegat
 
 // MARK: - VisitProposal extension
 
-private extension VisitProposal {
+extension VisitProposal {
     init(path: String = "", action: VisitAction = .advance, context: TurboNavigation.Context = .default, presentation: TurboNavigation.Presentation = .default) {
         let url = URL(string: "https://example.com")!.appendingPathComponent(path)
         let options = VisitOptions(action: action, response: nil)


### PR DESCRIPTION
I found a scenario we hadn't considered with TurboNavigator: there are times where pushing/replacing the modal controller with a navigation controller is expected. For example, presenting an `[EKEventEditViewController](https://developer.apple.com/documentation/eventkitui/ekeventeditviewcontroller)` so the user can add a new event to their calendar is currently not possible because `EKEventEditViewController` inherits from `UINavigationController`.

<img src="https://github.com/hotwired/turbo-ios/assets/253485/dc11c687-f1c6-4d1f-87e8-4f8706a07cb5" width="300" /> 

With the current implementation, `TurboNavigator` crashes when trying to push a `EKEventEditViewController` on a modal stack because it's disallowed to set a navigation controller as part of another navigation controller's view controllers (`modalNavigationController.setViewControllers([controller], animated: true)`).

I'm not particularly fond of the fix but I also don't see anything obviously wrong with it.