### PR TITLE
Adds ability to intercept visit failures by checking the url that failed

### DIFF
--- a/Source/Session/Session.swift
+++ b/Source/Session/Session.swift
@@ -179,7 +179,7 @@ extension Session: VisitDelegate {
     }
 
     func visit(_ visit: Visit, requestDidFailWithError error: Error) {
-        delegate?.session(self, didFailRequestForVisitable: visit.visitable, error: error, forURL: visit.location)
+        delegate?.session(self, didFailRequestForVisitable: visit.visitable, error: error)
     }
 
     func visitDidInitializeWebView(_ visit: Visit) {

--- a/Source/Session/Session.swift
+++ b/Source/Session/Session.swift
@@ -166,6 +166,10 @@ public class Session: NSObject {
 }
 
 extension Session: VisitDelegate {
+    func visitShouldFail(_ url: URL) -> Bool {
+        delegate?.sessionShouldFailRequest(url) ?? true
+    }
+    
     func visitRequestDidStart(_ visit: Visit) {
         delegate?.sessionDidStartRequest(self)
     }
@@ -175,7 +179,7 @@ extension Session: VisitDelegate {
     }
 
     func visit(_ visit: Visit, requestDidFailWithError error: Error) {
-        delegate?.session(self, didFailRequestForVisitable: visit.visitable, error: error)
+        delegate?.session(self, didFailRequestForVisitable: visit.visitable, error: error, forURL: visit.location)
     }
 
     func visitDidInitializeWebView(_ visit: Visit) {

--- a/Source/Session/SessionDelegate.swift
+++ b/Source/Session/SessionDelegate.swift
@@ -2,7 +2,7 @@ import UIKit
 
 public protocol SessionDelegate: AnyObject {
     func session(_ session: Session, didProposeVisit proposal: VisitProposal)
-    func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error)
+    func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error, forURL url: URL)
     
     func session(_ session: Session, openExternalURL url: URL)
     func session(_ session: Session, didReceiveAuthenticationChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
@@ -14,6 +14,8 @@ public protocol SessionDelegate: AnyObject {
     func sessionDidFinishFormSubmission(_ session: Session)
 
     func sessionWebViewProcessDidTerminate(_ session: Session)
+    
+    func sessionShouldFailRequest(_ url: URL) -> Bool
 }
 
 public extension SessionDelegate {

--- a/Source/Session/SessionDelegate.swift
+++ b/Source/Session/SessionDelegate.swift
@@ -2,7 +2,7 @@ import UIKit
 
 public protocol SessionDelegate: AnyObject {
     func session(_ session: Session, didProposeVisit proposal: VisitProposal)
-    func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error, forURL url: URL)
+    func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error)
     
     func session(_ session: Session, openExternalURL url: URL)
     func session(_ session: Session, didReceiveAuthenticationChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)

--- a/Source/Visit/ColdBootVisit.swift
+++ b/Source/Visit/ColdBootVisit.swift
@@ -78,26 +78,30 @@ extension ColdBootVisit: WKNavigationDelegate {
                 decisionHandler(.allow)
             } else {
                 decisionHandler(.cancel)
-                fail(with: TurboError.http(statusCode: httpResponse.statusCode))
+                guard let url = httpResponse.url else { return }
+                fail(with: TurboError.http(statusCode: httpResponse.statusCode), forURL: url)
             }
         } else {
             if (navigationResponse.response.url?.scheme == "blob") {
                 decisionHandler(.allow)
             } else {
                 decisionHandler(.cancel)
-                fail(with: TurboError.http(statusCode: 0))
+                guard let url = navigationResponse.response.url else { return }
+                fail(with: TurboError.http(statusCode: 0), forURL: url)
             }
         }
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
         guard navigation == self.navigation else { return }
-        fail(with: error)
+        guard let url = webView.url else { return }
+        fail(with: error, forURL: url)
     }
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
         guard navigation == self.navigation else { return }
-        fail(with: error)
+        guard let url = webView.url else { return }
+        fail(with: error, forURL: url)
     }
     
     func webView(_ webView: WKWebView, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {

--- a/Source/Visit/JavaScriptVisit.swift
+++ b/Source/Visit/JavaScriptVisit.swift
@@ -62,7 +62,8 @@ extension JavaScriptVisit: WebViewVisitDelegate {
         guard identifier == self.identifier else { return }
         
         log("didFailRequestForVisitWithIdentifier", ["identifier": identifier, "statusCode": statusCode])
-        fail(with: TurboError(statusCode: statusCode))
+        
+        fail(with: TurboError(statusCode: statusCode), forURL: location)
     }
     
     func webView(_ webView: WebViewBridge, didFinishRequestForVisitWithIdentifier identifier: String, date: Date) {

--- a/Source/Visit/Visit.swift
+++ b/Source/Visit/Visit.swift
@@ -58,11 +58,13 @@ class Visit: NSObject {
         delegate?.visitDidFinish(self)
     }
 
-    func fail(with error: Error) {
+    func fail(with error: Error, forURL url: URL) {
         guard state == .started else { return }
 
         state = .failed
-        delegate?.visit(self, requestDidFailWithError: error)
+        if delegate?.visitShouldFail(url) ?? true {
+            delegate?.visit(self, requestDidFailWithError: error)
+        }
         failVisit()
         delegate?.visitDidFail(self)
         delegate?.visitDidFinish(self)

--- a/Source/Visit/VisitDelegate.swift
+++ b/Source/Visit/VisitDelegate.swift
@@ -16,5 +16,7 @@ protocol VisitDelegate: AnyObject {
     func visit(_ visit: Visit, requestDidFailWithError error: Error)
     func visitRequestDidFinish(_ visit: Visit)
     
+    func visitShouldFail(_ url: URL) -> Bool
+    
     func visit(_ visit: Visit, didReceiveAuthenticationChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
 }


### PR DESCRIPTION
This PR adds a `sessionShouldFailRequest` delegate method to SessionDelegate allowing delegates to intercept visit failures before the `requestDidFailWithError` gets called. 

This is helpful in our case to prevent unnecessary logouts for when embedded links fail.
