### PR TITLE
Add bundle parameter to route

### DIFF
--- a/Source/Turbo Navigator/TurboNavigator.swift
+++ b/Source/Turbo Navigator/TurboNavigator.swift
@@ -43,10 +43,10 @@ public class TurboNavigator {
     ///
     /// - Parameter url: the URL to visit
     /// - Parameter bundle: provide context relevant to `url`
-    public func route(_ url: URL, bundle: [String: Any]? = nil) {
+    public func route(_ url: URL, parameters: [String: Any]? = nil) {
         let options = VisitOptions(action: .advance, response: nil)
         let properties = session.pathConfiguration?.properties(for: url) ?? PathProperties()
-        route(VisitProposal(url: url, options: options, properties: properties, bundle: bundle))
+        route(VisitProposal(url: url, options: options, properties: properties, parameters: parameters))
     }
 
     /// Transforms `VisitProposal` -> `UIViewController`

--- a/Source/Turbo Navigator/TurboNavigator.swift
+++ b/Source/Turbo Navigator/TurboNavigator.swift
@@ -42,7 +42,7 @@ public class TurboNavigator {
     /// Convenience function to routing a proposal directly.
     ///
     /// - Parameter url: the URL to visit
-    /// - Parameter bundle: provide context relevant to `url`
+    /// - Parameter parameters: provide context relevant to `url`
     public func route(_ url: URL, parameters: [String: Any]? = nil) {
         let options = VisitOptions(action: .advance, response: nil)
         let properties = session.pathConfiguration?.properties(for: url) ?? PathProperties()

--- a/Source/Turbo Navigator/TurboNavigator.swift
+++ b/Source/Turbo Navigator/TurboNavigator.swift
@@ -42,10 +42,11 @@ public class TurboNavigator {
     /// Convenience function to routing a proposal directly.
     ///
     /// - Parameter url: the URL to visit
-    public func route(_ url: URL) {
+    /// - Parameter bundle: provide context relevant to `url`
+    public func route(_ url: URL, bundle: [String: Any]? = nil) {
         let options = VisitOptions(action: .advance, response: nil)
         let properties = session.pathConfiguration?.properties(for: url) ?? PathProperties()
-        route(VisitProposal(url: url, options: options, properties: properties))
+        route(VisitProposal(url: url, options: options, properties: properties, bundle: bundle))
     }
 
     /// Transforms `VisitProposal` -> `UIViewController`

--- a/Source/Visit/VisitProposal.swift
+++ b/Source/Visit/VisitProposal.swift
@@ -4,10 +4,15 @@ public struct VisitProposal {
     public let url: URL
     public let options: VisitOptions
     public let properties: PathProperties
+    public let bundle: [String: Any]?
     
-    public init(url: URL, options: VisitOptions, properties: PathProperties = [:]) {
+    public init(url: URL, 
+                options: VisitOptions,
+                properties: PathProperties = [:],
+                bundle: [String: Any]? = nil) {
         self.url = url
         self.options = options
         self.properties = properties
+        self.bundle = bundle
     }
 }

--- a/Source/Visit/VisitProposal.swift
+++ b/Source/Visit/VisitProposal.swift
@@ -4,15 +4,15 @@ public struct VisitProposal {
     public let url: URL
     public let options: VisitOptions
     public let properties: PathProperties
-    public let bundle: [String: Any]?
+    public let parameters: [String: Any]?
     
     public init(url: URL, 
                 options: VisitOptions,
                 properties: PathProperties = [:],
-                bundle: [String: Any]? = nil) {
+                parameters: [String: Any]? = nil) {
         self.url = url
         self.options = options
         self.properties = properties
-        self.bundle = bundle
+        self.parameters = parameters
     }
 }


### PR DESCRIPTION
When routing, sometimes it's necessary to pass along information relevant to the URL. For example, we may route to a URL that ends up being a native controller and the native controller requires additional data for setting up.

Android has [something similar](https://github.com/hotwired/turbo-android/blob/f63e94ff3c5a47d8f92f48932a47cdcfc2f3205e/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavigator.kt#L50) when navigating.