### PR TITLE
Several improvements

### DIFF
--- a/Source/Turbo Navigator/Extensions/VisitProposalExtension.swift
+++ b/Source/Turbo Navigator/Extensions/VisitProposalExtension.swift
@@ -59,4 +59,13 @@ public extension VisitProposal {
 
         return VisitableViewController.pathConfigurationIdentifier
     }
+    
+    /// Allows the proposal to change the animation status when pushing, popping or presenting.
+    var animated: Bool {
+        if let animated = parameters?["animated"] as? Bool {
+            return animated
+        }
+        
+        return true
+    }
 }

--- a/Source/Turbo Navigator/TurboNavigator.swift
+++ b/Source/Turbo Navigator/TurboNavigator.swift
@@ -47,11 +47,12 @@ public class TurboNavigator {
     /// - Parameter url: the URL to visit
     /// - Parameter options: passed options will override any from the path configuration
     /// - Parameter parameters: provide context relevant to `url`
-    public func route(_ url: URL, options: VisitOptions? = nil, parameters: [String: Any]? = nil) {
-        let defaultOptions = VisitOptions(action: .advance, response: nil)
+    public func route(_ url: URL,
+                      options: VisitOptions = VisitOptions(action: .advance),
+                      parameters: [String: Any]? = nil) {
         let properties = session.pathConfiguration?.properties(for: url) ?? PathProperties()
         route(VisitProposal(url: url,
-                            options: options ?? defaultOptions,
+                            options: options,
                             properties: properties,
                             parameters: parameters))
     }

--- a/Source/Turbo Navigator/TurboNavigator.swift
+++ b/Source/Turbo Navigator/TurboNavigator.swift
@@ -11,6 +11,9 @@ public class TurboNavigator {
     public unowned var delegate: TurboNavigatorDelegate
 
     public var rootViewController: UINavigationController { hierarchyController.navigationController }
+    
+    public var modalRootViewController: UINavigationController { hierarchyController.modalNavigationController }
+    
     public var activeNavigationController: UINavigationController { hierarchyController.activeNavigationController }
 
     /// Set to handle customize behavior of the `WKUIDelegate`.

--- a/Source/Turbo Navigator/TurboNavigator.swift
+++ b/Source/Turbo Navigator/TurboNavigator.swift
@@ -49,7 +49,7 @@ public class TurboNavigator {
     /// - Parameter parameters: provide context relevant to `url`
     public func route(_ url: URL, options: VisitOptions? = nil, parameters: [String: Any]? = nil) {
         let defaultOptions = VisitOptions(action: .advance, response: nil)
-        var properties = session.pathConfiguration?.properties(for: url) ?? PathProperties()
+        let properties = session.pathConfiguration?.properties(for: url) ?? PathProperties()
         route(VisitProposal(url: url,
                             options: options ?? defaultOptions,
                             properties: properties,

--- a/Source/Turbo Navigator/TurboNavigator.swift
+++ b/Source/Turbo Navigator/TurboNavigator.swift
@@ -45,14 +45,14 @@ public class TurboNavigator {
     /// Convenience function to routing a proposal directly.
     ///
     /// - Parameter url: the URL to visit
-    /// - Parameter options: passed options will override any from the path configuration
+    /// - Parameter options: passed options will override default `advance` visit options
     /// - Parameter parameters: provide context relevant to `url`
     public func route(_ url: URL,
-                      options: VisitOptions = VisitOptions(action: .advance),
+                      options: VisitOptions? = VisitOptions(action: .advance),
                       parameters: [String: Any]? = nil) {
         let properties = session.pathConfiguration?.properties(for: url) ?? PathProperties()
         route(VisitProposal(url: url,
-                            options: options,
+                            options: options ?? .init(action: .advance),
                             properties: properties,
                             parameters: parameters))
     }

--- a/Source/Turbo Navigator/TurboNavigator.swift
+++ b/Source/Turbo Navigator/TurboNavigator.swift
@@ -42,11 +42,15 @@ public class TurboNavigator {
     /// Convenience function to routing a proposal directly.
     ///
     /// - Parameter url: the URL to visit
+    /// - Parameter options: passed options will override any from the path configuration
     /// - Parameter parameters: provide context relevant to `url`
-    public func route(_ url: URL, parameters: [String: Any]? = nil) {
-        let options = VisitOptions(action: .advance, response: nil)
-        let properties = session.pathConfiguration?.properties(for: url) ?? PathProperties()
-        route(VisitProposal(url: url, options: options, properties: properties, parameters: parameters))
+    public func route(_ url: URL, options: VisitOptions? = nil, parameters: [String: Any]? = nil) {
+        let defaultOptions = VisitOptions(action: .advance, response: nil)
+        var properties = session.pathConfiguration?.properties(for: url) ?? PathProperties()
+        route(VisitProposal(url: url,
+                            options: options ?? defaultOptions,
+                            properties: properties,
+                            parameters: parameters))
     }
 
     /// Transforms `VisitProposal` -> `UIViewController`

--- a/Tests/Turbo Navigator/TurboNavigatorTests.swift
+++ b/Tests/Turbo Navigator/TurboNavigatorTests.swift
@@ -17,12 +17,23 @@ final class TurboNavigationHierarchyControllerTests: XCTestCase {
         loadNavigationControllerInWindow()
     }
 
-    func test_default_default_default_pushesOnMainStack() {
+    func test_default_default_default_defaultOptionsParamater_pushesOnMainStack() {
         navigator.route(oneURL)
         XCTAssertEqual(navigationController.viewControllers.count, 1)
         XCTAssert(navigator.rootViewController.viewControllers.last is VisitableViewController)
 
         navigator.route(twoURL)
+        XCTAssertEqual(navigationController.viewControllers.count, 2)
+        XCTAssert(navigator.rootViewController.viewControllers.last is VisitableViewController)
+        assertVisited(url: twoURL, on: .main)
+    }
+    
+    func test_default_default_default_nilOptionsParameter_pushesOnMainStack() {
+        navigator.route(oneURL)
+        XCTAssertEqual(navigationController.viewControllers.count, 1)
+        XCTAssert(navigator.rootViewController.viewControllers.last is VisitableViewController)
+
+        navigator.route(twoURL, options: nil)
         XCTAssertEqual(navigationController.viewControllers.count, 2)
         XCTAssert(navigator.rootViewController.viewControllers.last is VisitableViewController)
         assertVisited(url: twoURL, on: .main)


### PR DESCRIPTION
This PR contains three changes for my convenience, but I'm happy to break them up into 3 separate PRs if needed:

- `TurboNavigator.rootViewcontroller` allowed us to access the main nav controller. I've added `modalRootViewController` so we can access that too.
- I've added an "animated" key to VisitProposal. This is a first step towards allowing native clients to use custom animations while TurboNavigator handles hierarchy.
- Finally, when routing, I've added an `options` parameter. This is useful when you want to override the options given from the path config dynamically.

Happy to hear any feedback.