### PR TITLE
Remove empty view controller when intercepting unauthorized requests for Demo app

### DIFF
--- a/Demo/SceneController.swift
+++ b/Demo/SceneController.swift
@@ -36,6 +36,7 @@ final class SceneController: UIResponder {
     // MARK: - Authentication
     
     private func promptForAuthentication() {
+        navigationController.popViewController(animated: false)
         let authURL = rootURL.appendingPathComponent("/signin")
         let properties = pathConfiguration.properties(for: authURL)
         navigationController.route(url: authURL, options: VisitOptions(), properties: properties)


### PR DESCRIPTION
This avoids having an empty view controller behind the modal when intercepting unauthorized requests in the Demo app

https://github.com/hotwired/turbo-ios/assets/63070125/4d9b785c-5fd0-4d35-b7a9-3aa43f6c558d

