### PR TITLE
Explain swift regex and the need to escape backslashes

### DIFF
--- a/Docs/PathConfiguration.md
+++ b/Docs/PathConfiguration.md
@@ -139,7 +139,7 @@ if let enableFeatureX = pathConfiguration.settings["enable-feature-x"] as? Bool 
 
 ### Swift Regex
 
-The Turbo IOS framework uses `NSRegularExpression` swift class to evaluate regex expressions. Something to note is you need to escape back slashes `\` becauses they are special charectars in Swift to do this add a second backslash `\\d`
+The Turbo IOS framework uses `NSRegularExpression` swift class to evaluate regular expressions. Something to note is you need to escape back slashes `\` because it is a special charectars in Swift to do this add a second backslash `\\d`
 
 ```json
 [

--- a/Docs/PathConfiguration.md
+++ b/Docs/PathConfiguration.md
@@ -137,3 +137,20 @@ if let enableFeatureX = pathConfiguration.settings["enable-feature-x"] as? Bool 
 }
 ```
 
+### Swift Regex
+
+The Turbo IOS framework uses `NSRegularExpression` swift class to evaluate regex expressions. Something to note is you need to escape back slashes `\` becauses they are special charectars in Swift to do this add a second backslash `\\d`
+
+```json
+[
+    {
+      "patterns": [
+        "/numbers/\\d+$"
+      ],
+      "properties": {
+        "view-controller": "numbersDetail",
+        "presentation": "modal"
+      }
+    },
+]
+```


### PR DESCRIPTION
This addition to the docs is to explain the need for escaping backslashes in the path configuration file
I struggled with this for a while not knowing why the path configuration was failing so this addition should make things alot easier to understand for developers who are new to Swift.
