### PR TITLE
Check for presenting instead of presented

### DIFF
--- a/Source/Turbo Navigator/TurboNavigationHierarchyController.swift
+++ b/Source/Turbo Navigator/TurboNavigationHierarchyController.swift
@@ -87,6 +87,8 @@ class TurboNavigationHierarchyController {
             }
         case .modal:
             if modalNavigationController.presentingViewController != nil, !modalNavigationController.isBeingDismissed {
+                /// Avoids `Attempt to present on which is already presenting.` in case a modal is being presented.
+                navigationController.dismiss(animated: proposal.animated)
                 pushOrReplace(on: modalNavigationController, with: controller, via: proposal)
             } else {
                 modalNavigationController.setViewControllers([controller], animated: proposal.animated)

--- a/Source/Turbo Navigator/TurboNavigationHierarchyController.swift
+++ b/Source/Turbo Navigator/TurboNavigationHierarchyController.swift
@@ -86,7 +86,7 @@ class TurboNavigationHierarchyController {
                 delegate.visit(visitable, on: .main, with: proposal.options)
             }
         case .modal:
-            if navigationController.presentedViewController != nil, !modalNavigationController.isBeingDismissed {
+            if modalNavigationController.presentingViewController != nil, !modalNavigationController.isBeingDismissed {
                 pushOrReplace(on: modalNavigationController, with: controller, via: proposal)
             } else {
                 modalNavigationController.setViewControllers([controller], animated: proposal.animated)


### PR DESCRIPTION
I found another small issue. It's possible that users present a screen modally outside of TurboNavigator on TurboNavigator's main navigation controller. 

For example:

1. A URL request fails.
2. A custom alert ("Cancel", "Settings") is presented in `turboNavigator.rootViewController`.
3. "Settings" is tapped.
4. `route(url: settings)` is proposed.

**Expected:** 5. `turboNavigator.modalRootViewController` is presented with `Settings` as its root view controller.
**Current:** 5. `turboNavigator.rootViewController` is already presenting (the alert) so `Settings` is pushed to `turboNavigator.modalRootViewController` which exists but is not presented.

The current behavior assumes `TurboNavigator` itself has presented the custom alert (2.) but no modal has actually been presented via `route(url:)`. This causes future modals proposed through `route(url:)` (4.) to never be presented. Instead, they're pushed/replaced on `modalRootViewController` since TurboNavigator believes it is already visible.

Instead of checking whether the main nav controller has a presented modal, check if TurboNavigator's modal stack is being presented. This way, manually presenting a modal does not interfere with TurboNavigator's modal stack.