### PR TITLE
Cache based on url

### DIFF
--- a/Tests/PathConfigurationLoaderTests.swift
+++ b/Tests/PathConfigurationLoaderTests.swift
@@ -55,7 +55,7 @@ class PathConfigurationLoaderTests: XCTestCase {
         wait(for: [expectation])
 
         XCTAssertTrue(handlerCalled)
-        XCTAssertTrue(FileManager.default.fileExists(atPath: loader.configurationCacheURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: loader.configurationCacheURL(for: serverURL).path))
     }
 
     private func stubRequest(for loader: PathConfigurationLoader) -> XCTestExpectation {
@@ -64,7 +64,7 @@ class PathConfigurationLoaderTests: XCTestCase {
             return HTTPStubsResponse(jsonObject: json, statusCode: 200, headers: [:])
         }
 
-        clearCache(loader.configurationCacheURL)
+        clearCache(loader.configurationCacheURL(for: serverURL))
 
         return expectation(description: "Wait for configuration to load.")
     }


### PR DESCRIPTION
Adds new caching behavior for path config.

Previously, we'd cache the last successfully downloaded version of a path config. This causes an issue when a user updates versions (e.g. path-config-v6.json to path-config-v7.json). Instead of saving the last successfully downloaded version, we now use the path's last component (i.e. the filename) for cache purposes.