### PR TITLE
Fix refresh behavior

### DIFF
--- a/Source/Turbo Navigator/TurboNavigationHierarchyController.swift
+++ b/Source/Turbo Navigator/TurboNavigationHierarchyController.swift
@@ -168,21 +168,28 @@ class TurboNavigationHierarchyController {
         if navigationController.presentedViewController != nil {
             if modalNavigationController.viewControllers.count == 1 {
                 navigationController.dismiss(animated: proposal.animated)
-                delegate.refresh(navigationStack: .main)
+                refreshIfTopViewControllerIsVisitable(from: .main)
             } else {
                 modalNavigationController.popViewController(animated: proposal.animated)
-                delegate.refresh(navigationStack: .modal)
+                refreshIfTopViewControllerIsVisitable(from: .modal)
             }
         } else {
             navigationController.popViewController(animated: proposal.animated)
-            delegate.refresh(navigationStack: .main)
+            refreshIfTopViewControllerIsVisitable(from: .main)
+        }
+    }
+    
+    private func refreshIfTopViewControllerIsVisitable(from stack: NavigationStackType) {
+        if let navControllerTopmostVisitable = navController(for: stack).topViewController as? Visitable {
+            delegate.refreshVisitable(navigationStack: stack,
+                                      newTopmostVisitable: navControllerTopmostVisitable)
         }
     }
 
     private func clearAll(via proposal: VisitProposal) {
         navigationController.dismiss(animated: proposal.animated)
         navigationController.popToRootViewController(animated: proposal.animated)
-        delegate.refresh(navigationStack: .main)
+        refreshIfTopViewControllerIsVisitable(from: .main)
     }
 
     private func replaceRoot(with controller: UIViewController, via proposal: VisitProposal) {

--- a/Source/Turbo Navigator/TurboNavigationHierarchyControllerDelegate.swift
+++ b/Source/Turbo Navigator/TurboNavigationHierarchyControllerDelegate.swift
@@ -1,9 +1,23 @@
 import SafariServices
 import WebKit
 
-/// Implement to be notified when certain navigations are performed
-/// or to render a native controller instead of a Turbo web visit.
 protocol TurboNavigationHierarchyControllerDelegate: AnyObject {
-    func visit(_ : Visitable, on: TurboNavigationHierarchyController.NavigationStackType, with: VisitOptions)
-    func refresh(navigationStack: TurboNavigationHierarchyController.NavigationStackType)
+    
+    /// Once the navigation hierarchy is modified, begin a visit on a navigation controller.
+    ///
+    /// - Parameters:
+    ///   - _: the Visitable destination
+    ///   - on: the navigation controller that was modified
+    ///   - with: the visit options
+    func visit(_ : Visitable,
+               on: TurboNavigationHierarchyController.NavigationStackType,
+               with: VisitOptions)
+    
+    /// A refresh will pop (or dismiss) then ask the session to refresh the previous (or underlying) Visitable.
+    ///
+    /// - Parameters:
+    ///   - navigationStack: the stack where the refresh is happening
+    ///   - newTopmostVisitable: the visitable to be refreshed
+    func refreshVisitable(navigationStack: TurboNavigationHierarchyController.NavigationStackType,
+                          newTopmostVisitable: Visitable)
 }

--- a/Source/Turbo Navigator/TurboNavigator.swift
+++ b/Source/Turbo Navigator/TurboNavigator.swift
@@ -219,9 +219,9 @@ extension TurboNavigator: TurboNavigationHierarchyControllerDelegate {
                           newTopmostVisitable: any Visitable) {
         switch navigationStack {
         case .main:
-            session.visit(newTopmostVisitable, reload: true)
+            session.visit(newTopmostVisitable, action: .restore)
         case .modal:
-            modalSession.visit(newTopmostVisitable, reload: true)
+            modalSession.visit(newTopmostVisitable, action: .restore)
         }
     }
 }

--- a/Source/Turbo Navigator/TurboNavigator.swift
+++ b/Source/Turbo Navigator/TurboNavigator.swift
@@ -215,10 +215,13 @@ extension TurboNavigator: TurboNavigationHierarchyControllerDelegate {
         }
     }
 
-    func refresh(navigationStack: TurboNavigationHierarchyController.NavigationStackType) {
+    func refreshVisitable(navigationStack: TurboNavigationHierarchyController.NavigationStackType,
+                          newTopmostVisitable: any Visitable) {
         switch navigationStack {
-        case .main: session.reload()
-        case .modal: modalSession.reload()
+        case .main:
+            session.visit(newTopmostVisitable, reload: true)
+        case .modal:
+            modalSession.visit(newTopmostVisitable, reload: true)
         }
     }
 }


### PR DESCRIPTION
While testing, I found that when a visit with a refresh presentation is proposed, `TurboNavigatorHierarchyController` will correctly pop (or dismiss) and then ask the session to reload. However, the session does not know that the topmost visitable changed, so a reload will end up reloading the _last_ successfully loaded visit – the visitable that was just popped (or dismissed).

