### PR TITLE
Allows for custom headers

### DIFF
--- a/Source/Session/Session.swift
+++ b/Source/Session/Session.swift
@@ -21,6 +21,8 @@ public class Session: NSObject {
     private var isShowingStaleContent = false
     private var isSnapshotCacheStale = false
 
+    public var customHeaders: [String: String] = [:]
+    
     /// Automatically creates a web view with the passed-in configuration
     public convenience init(webViewConfiguration: WKWebViewConfiguration? = nil) {
         self.init(webView: WKWebView(frame: .zero, configuration: webViewConfiguration ?? WKWebViewConfiguration()))
@@ -300,6 +302,11 @@ extension Session: VisitableDelegate {
         refreshing = true
         visitable.visitableWillRefresh()
         reload()
+    }
+    public func visitableCustomizeRequest(_ request: inout URLRequest) {
+        for (key, value) in customHeaders {
+            request.setValue(value, forHTTPHeaderField: key)
+        }
     }
 }
 

--- a/Source/Visit/ColdBootVisit.swift
+++ b/Source/Visit/ColdBootVisit.swift
@@ -15,7 +15,9 @@ final class ColdBootVisit: Visit {
         if let response = options.response, response.isSuccessful, let body = response.responseHTML {
             navigation = webView.loadHTMLString(body, baseURL: location)
         } else {
-            navigation = webView.load(URLRequest(url: location))
+            var request = URLRequest(url: location)
+            visitable.visitableDelegate?.visitableCustomizeRequest(&request)
+            navigation = webView.load(request)
         }
 
         delegate?.visitDidStart(self)

--- a/Source/Visitable/Visitable.swift
+++ b/Source/Visitable/Visitable.swift
@@ -8,6 +8,7 @@ public protocol VisitableDelegate: AnyObject {
     func visitableViewDidDisappear(_ visitable: Visitable)
     func visitableDidRequestReload(_ visitable: Visitable)
     func visitableDidRequestRefresh(_ visitable: Visitable)
+    func visitableCustomizeRequest(_ request: inout URLRequest)
 }
 
 public protocol Visitable: AnyObject {
@@ -81,6 +82,9 @@ extension Visitable {
 
     func visitableViewDidRequestRefresh() {
         visitableDelegate?.visitableDidRequestRefresh(self)
+    }
+    func visitableCustomizeRequest(_ request: inout URLRequest){
+        // no op
     }
 }
 


### PR DESCRIPTION
Adds ability to send custom headers.  This is key for testing purposes allowing certain builds through security mechanisms. 

```swift
let session = Session(webView: webView)
session.delegate = self
session.pathConfiguration = pathConfiguration
session.customHeaders["CF-Access-Client-Id"] = "<token>.access"
session.customHeaders["CF-Access-Client-Secret"] = "<secret>"
```