### PR TITLE
Avoid popping the view controller on refresh if the presentedViewController is nil

### DIFF
--- a/Source/Turbo Navigator/TurboNavigationHierarchyController.swift
+++ b/Source/Turbo Navigator/TurboNavigationHierarchyController.swift
@@ -174,7 +174,6 @@ class TurboNavigationHierarchyController {
                 refreshIfTopViewControllerIsVisitable(from: .modal)
             }
         } else {
-            navigationController.popViewController(animated: proposal.animated)
             refreshIfTopViewControllerIsVisitable(from: .main)
         }
     }


### PR DESCRIPTION
# Issue
When triggering a refresh on a view, the application incorrectly redirects back and refreshes the previous view in the navigation stack.

# Assumption
If `navigationController.presentedViewController` is not nil, a modal is assumed to be displayed, and the expected behavior is to pop the view controller and dismiss the modal.

# Resolution
Only pop the view controller when `presentedViewController` is not nil. If presentedViewController is nil, avoid popping the view controller to prevent unintended navigation behavior.