### PR TITLE
Update QuickStartGuide - add library

### DIFF
--- a/Docs/QuickStartGuide.md
+++ b/Docs/QuickStartGuide.md
@@ -4,9 +4,11 @@ This is a quick start guide to creating the most minimal Turbo iOS application f
 
 1. First, create a new iOS app from the Xcode File > New > Project menu and choose the default iOS "App" template. Note: When using XCode >= 12, be sure to choose "Storyboard" under "Interface" and "UIKit App Delegate" under "Lifecycle" in the project creation dialog. 
 
-2. Select your app's main top-level project, go to the Swift Packages tab and add the Turbo iOS dependency by entering in `https://github.com/hotwired/turbo-ios`.
+2. Select your app's main top-level project in the Navigator panel, and select the project in the Project and Targets list, and go to the Dependencies tab and add the Turbo iOS dependency by entering in `https://github.com/hotwired/turbo-ios`.
 
-3. Open the `SceneDelegate`, and replace the entire file with this code:
+3. In the Project and Targets List, select the main Target, and in the General tab, scroll down to Frameworks, Libraries, and Embedded Content. Add the Turbo Library within the Turbo Package.
+
+4. Open the `SceneDelegate`, and replace the entire file with this code:
 ```swift
 import UIKit
 import Turbo
@@ -49,8 +51,8 @@ extension SceneDelegate: SessionDelegate {
 }
 ```
 
-4. Hit run, and you have a basic working app. You can now tap links and navigate the demo back and forth in the simulator. We've only touched the very core requirements here of creating a `Session` and handling a visit.
+5. Hit run, and you have a basic working app. You can now tap links and navigate the demo back and forth in the simulator. We've only touched the very core requirements here of creating a `Session` and handling a visit.
 
-5. You can change the url we use for the initial visit to your web app. Note: if you're running your app locally without https, you'll need to adjust your `NSAppTransportSecurity` settings in the Info.plist to allow arbitrary loads.
+6. You can change the url we use for the initial visit to your web app. Note: if you're running your app locally without https, you'll need to adjust your `NSAppTransportSecurity` settings in the Info.plist to allow arbitrary loads.
 
-6. A real application will want to customize the view controller, respond to different visit actions, gracefully handle errors, and build a more powerful routing system. Read the rest of the documentation to learn more.
+7. A real application will want to customize the view controller, respond to different visit actions, gracefully handle errors, and build a more powerful routing system. Read the rest of the documentation to learn more.


### PR DESCRIPTION
In XCode 15.4 and 16, the instructions in the Quickstart guide don't work. We need to add the Turbo library to the target after installing the package.