### PR TITLE
Note Hotwire Native in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 **Build high-fidelity hybrid apps with native navigation and a single shared web view.** Turbo Native for iOS provides the tooling to wrap your [Turbo 7](https://github.com/hotwired/turbo)-enabled web app in a native iOS shell. It manages a single WKWebView instance across multiple view controllers, giving you native navigation UI with all the client-side performance benefits of Turbo.
 
+> [!IMPORTANT]
+> [Hotwire Native](https://native.hotwired.dev) is the consolidation of the Turbo Native and Strada libraries into a single framework for iOS and Android. Going forward, the Hotwire umbrella of libraries now includes: Turbo + Stimulus + Native.
+
 ## Features
 
 - **Deliver fast, efficient hybrid apps.** Avoid reloading JavaScript and CSS. Save memory by sharing one WKWebView.


### PR DESCRIPTION
Note Hotwire Native at the top of the README for folks just discovering Turbo Native.

<img width="928" alt="image" src="https://github.com/user-attachments/assets/4843557f-31ef-4da9-9a34-ce641346d20e">